### PR TITLE
Major refactor and compliance with reST / PEP 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Useful for shows like Yuru Camp with bad lineart problems.
 
 If eedi3=False, it will use Nnedi3 instead.
 
-### nneedi3
+### nneedi3_clamp
 
 Function written by Zastin. <br>
 What it does is clamp the "change" done by Eedi3 to the "change" of Nnedi3. <br>

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ Contains functions I've written (and rewritten from others) for use in VapourSyn
 
 This function offers the following:</br>
 
-- compare(clip_a, clip_b, frames: int, mark=False, mark_a=' Clip A ', mark_b=' Clip B ', fontsize=57)
-- stack_compare(clips, width=None, height=None, stack_vertical=False):
-- conditional_descale(src, height, b=1/3, c=1/3, threshold=0.003, w2x=False)
-- transpose_aa(clip, eedi3=False)
-- NnEedi3(clip, mask, strong_mask, show_mask, strength=1, alpha=0.25, beta=0.5, gamma=40, nrad=2, mdis=20, nsize=3, nns=3, qual=1)
-- quick_denoise(clip, mode='knlm', bm3d=True, sigma=3, h=1.0, refine_motion=True, sbsize=16, resample=True)
-- stack_planes(src, stack_vertical=False)
-- source(file, force_lsmas=False, src=None, fpsnum=None, fpsden=None)
+- compare(clip_a, clip_b, frames: int, mark: bool, mark_a: str, mark_b: str, fontsize: int)
+- stack_compare(clips, width: int, height: int, stack_vertical: bool)
+- conditional_descale(src, height: int, b: float, c: float, threshold: float, w2x: bool)
+- transpose_aa(clip, eedi3: bool)
+- nneedi3_clamp(clip, mask, strong_mask: bool, show_mask: bool, opencl: bool, strength=1, alpha: float, beta: float, gamma=40, nrad=2, mdis=20, nsize=3, nns=3, qual=1)
+- quick_denoise(src, sigma=4, cmode='knlm', ref, **kwargs)
+- stack_planes(src, stack_vertical: bool)
+- source(file, force_lsmas: bool, ref, fpsnum: int, fpsden: int)
 
 ## Requirements:
 
@@ -17,20 +17,27 @@ This function offers the following:</br>
 
 ## Dependencies:
 
-- [vsTAAmbk](https://github.com/HomeOfVapourSynthEvolution/vsTAAmbk)
 - [fvsfunc](https://github.com/Irrational-Encoding-Wizardry/fvsfunc)
-- [mvsfunc](https://github.com/HomeOfVapourSynthEvolution/mvsfunc)
 - [havsfunc](https://github.com/HomeOfVapourSynthEvolution/havsfunc)
 - [kagefunc](https://github.com/Irrational-Encoding-Wizardry/kagefunc)
-- [vsutil](https://github.com/Irrational-Encoding-Wizardry/vsutil)
+- [mvsfunc](https://github.com/HomeOfVapourSynthEvolution/mvsfunc)
 - [nnedi3_rpow2](https://github.com/darealshinji/vapoursynth-plugins/blob/master/scripts/nnedi3_rpow2.py)
+- [vsTAAmbk](https://github.com/HomeOfVapourSynthEvolution/vsTAAmbk)
+- [vsutil](https://github.com/Irrational-Encoding-Wizardry/vsutil)
 
+### Optional dependencies:
+- waifu2x-caffe
+- L-SMASH Source
+- d2vsource
+- FFMS2
+
+Can be found at <http://www.vapoursynth.com/doc/pluginlist.html>
 
 ## Functions:
 
 ### Compare
 Allows for the same frames from two different clips to be compared by putting them next to each other in a list. <br>
-Shorthand for this function is *"comp"*.
+Shorthand for this function is `comp`.
 
 **Example usage:**
 ```py
@@ -42,7 +49,7 @@ comp = lvf.compare(src_a, src_b, frames=[100,200,300])
 ### stack_compare
 A simple wrapper that allows you to compare two clips by stacking them. <br>
 You can stack an infinite amount of clips. <br>
-Shorthand for this function is *"scomp"*.
+Shorthand for this function is `scomp`.
 
 **Example usage:**
 ```py
@@ -89,9 +96,9 @@ Performs anti-aliasing over a clip by using nnedi3, transposing, using nnedi3 ag
 This results in overall stronger aliasing. <br>
 Useful for shows like Yuru Camp with bad lineart problems.
 
-If Eedi3=False, it will use Nnedi3 instead.
+If eedi3=False, it will use Nnedi3 instead.
 
-### NnEedi3
+### nneedi3
 
 Function written by Zastin. <br>
 What it does is clamp the "change" done by Eedi3 to the "change" of Nnedi3. <br>
@@ -107,7 +114,8 @@ Stacks the planes of a clip.
 
 Generic clip import function. <br>
 Automatically determines if ffms2 or L-SMASH should be used to import a clip, but L-SMASH can be forced. <br>
-It also automatically determines if an image has been imported. You can set its fps using `fpsnum` and `fpsden`, or using a reference clip with `src`.
+It also automatically determines if an image has been imported. You can set its fps using `fpsnum` and `fpsden`, or using a reference clip with `ref`. <br>
+Shorthand for this function is `src`.
 
 **Example usage:**
 
@@ -122,5 +130,5 @@ Importing a custom mask, converting it to GRAY, binarizing it, and making is 215
 ```py
 import lvsfunc as lvf
 
-mask = lvf.src(r'mask.png', src).resize.Point(format=vs.GRAY8, matrix_s='709').std.Binarize()*2156
+mask = lvf.src(r'mask.png', ref=clip_a).resize.Point(format=vs.GRAY8, matrix_s='709').std.Binarize()*2156
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This function offers the following:</br>
 
 - compare(clip_a, clip_b, frames: int, mark: bool, mark_a: str, mark_b: str, fontsize: int)
 - stack_compare(clips, width: int, height: int, stack_vertical: bool)
-- conditional_descale(src, height: int, b: float, c: float, threshold: float, w2x: bool)
+- conditional_descale(clip, height: int, b: float, c: float, threshold: float, w2x: bool)
 - transpose_aa(clip, eedi3: bool)
 - nneedi3_clamp(clip, mask, strong_mask: bool, show_mask: bool, opencl: bool, strength=1, alpha: float, beta: float, gamma=40, nrad=2, mdis=20, nsize=3, nns=3, qual=1)
-- quick_denoise(src, sigma=4, cmode='knlm', ref, **kwargs)
-- stack_planes(src, stack_vertical: bool)
+- quick_denoise(clip, sigma=4, cmode='knlm', ref, **kwargs)
+- stack_planes(clip, stack_vertical: bool)
 - source(file, force_lsmas: bool, ref, fpsnum: int, fpsden: int)
 
 ## Requirements:
@@ -43,7 +43,7 @@ Shorthand for this function is `comp`.
 ```py
 import lvsfunc as lvf
 
-comp = lvf.compare(src_a, src_b, frames=[100,200,300])
+comp = lvf.compare(clip_a, clip_b, frames=[100,200,300])
 ```
 
 ### stack_compare
@@ -55,7 +55,7 @@ Shorthand for this function is `scomp`.
 ```py
 import lvsfunc as lvf
 
-scomp = lvf.stack_compare(src_a, src_b, src_c, height=480)
+scomp = lvf.stack_compare(clip_a, clip_b, clip_c, height=480)
 ```
 
 ### conditional_descale
@@ -72,7 +72,7 @@ Standard usage
 ```py
 import lvsfunc as lvf
 
-descaled = lvf.conditional_descale(src, height=540, b=0, c=1)
+descaled = lvf.conditional_descale(clip, height=540, b=0, c=1)
 ```
 
 Scenefiltering the Opening and Ending of an anime
@@ -82,9 +82,9 @@ import fvsfunc as fvf
 import kagefunc as kgf
 from nnedi3_rpow2 import nnedi3_rpow2
 
-descaled_a = lvf.conditional_descale(src, height=540, b=0, c=1, w2x=True)
-descaled_b = kgf.inverse_scale(src, height=540, kernel='bicubic', b=0, c=1, mask_detail=True)
-descaled_b = nnedi3_rpow2(descaled_b).resize.Spline36(src.width, src.height)
+descaled_a = lvf.conditional_descale(clip, height=540, b=0, c=1, w2x=True)
+descaled_b = kgf.inverse_scale(clip, height=540, kernel='bicubic', b=0, c=1, mask_detail=True)
+descaled_b = nnedi3_rpow2(descaled_b).resize.Spline36(clip.width, clip.height)
 
 descaled = fvf.rfs(descaled_a, descaled_b, mappings=f"[{opstart} {opstart+2159}] [{edstart} {edstart+2157}]")
 ```
@@ -123,7 +123,7 @@ Importing a standard clip
 ```py
 import lvsfunc as lvf
 
-src = lvf.src("BDMV/STREAM/00000.m2ts")
+bluray = lvf.src("BDMV/STREAM/00000.m2ts")
 ```
 
 Importing a custom mask, converting it to GRAY, binarizing it, and making is 2156 frames long.

--- a/lvsfunc.py
+++ b/lvsfunc.py
@@ -160,7 +160,7 @@ def transpose_aa(clip: vs.VideoNode, eedi3: bool = False) -> vs.VideoNode:
     return aaclip if clip.format.color_family is vs.GRAY else core.std.ShufflePlanes([aaclip, clip], [0, 1, 2], vs.YUV)
 
 
-def nneedi3_clamp(clip: vs.VideoNode, mask=None, strong_mask: bool = False, show_mask: bool = False,
+def nneedi3_clamp(clip: vs.VideoNode, mask: vs.VideoNode=None, strong_mask: bool = False, show_mask: bool = False,
                   opencl: bool = False, strength=1, alpha: float = 0.25, beta: float = 0.5, gamma=40, nrad=2, mdis=20,
                   nsize=3, nns=3, qual=1) -> vs.VideoNode:
     """

--- a/lvsfunc.py
+++ b/lvsfunc.py
@@ -1,20 +1,47 @@
 """
-    Various functions I make use of often and other people might be able to use too. Suggestions and fixes are always appreciated!
+    Various functions I make use of often and other people might be able to use too.
+    Suggestions and fixes are always appreciated!
 """
 
-import vapoursynth as vs
-import kagefunc as kgf # https://github.com/Irrational-Encoding-Wizardry/kagefunc
-import vsutil # https://github.com/Irrational-Encoding-Wizardry/vsutil
+from functools import partial
+
+import fvsfunc as fvf  # https://github.com/Irrational-Encoding-Wizardry/fvsfunc
+import havsfunc as hvf  # https://github.com/HomeOfVapourSynthEvolution/havsfunc
+import kagefunc as kgf  # https://github.com/Irrational-Encoding-Wizardry/kagefunc
+import mvsfunc as mvf  # https://github.com/HomeOfVapourSynthEvolution/mvsfunc
+from vsTAAmbk import TAAmbk  # https://github.com/HomeOfVapourSynthEvolution/vsTAAmbk
+from vsutil import *  # https://github.com/Irrational-Encoding-Wizardry/vsutil
+
+from nnedi3_rpow2 import \
+    nnedi3_rpow2  # https://github.com/darealshinji/vapoursynth-plugins/blob/master/scripts/nnedi3_rpow2.py
+
 core = vs.core
+# optional requires: (http://www.vapoursynth.com/doc/pluginlist.html)
+#   waifu2x-caffe
+#   L-SMASH Source
+#   d2vsource
+#   FFMS2
 
-# TO-DO: Write function that only masks px of a certain color/threshold of colors
+# TODO: Write function that only masks px of a certain color/threshold of colors
 
 
-def compare(clip_a: vs.VideoNode, clip_b: vs.VideoNode, frames: int, mark=False, mark_a=' Clip A ', mark_b=' Clip B ', fontsize=57):
+def compare(clip_a: vs.VideoNode, clip_b: vs.VideoNode, *frames: int, mark: bool = False, mark_a: str = ' Clip A ',
+            mark_b: str = ' Clip B ',
+            fontsize: int = 57) -> vs.VideoNode:
     """
     Allows for the same frames from two different clips to be compared by putting them next to each other in a list.
-
+    
     Shorthand for this function is "comp".
+
+    :param clip_a: vs.VideoNode: 
+    :param clip_b: vs.VideoNode: 
+    :param frames: int:
+    :param mark: bool:  (Default value = False)
+    :param mark_a: str:  (Default value = ' Clip A ')
+    :param mark_b: str:  (Default value = ' Clip B ')
+    :param fontsize: int:  (Default value = 57)
+    :returns: vs.VideoNode clip
+
     """
     if clip_a.format.id != clip_b.format.id:
         raise ValueError('compare: The format of both clips must be equal')
@@ -29,132 +56,169 @@ def compare(clip_a: vs.VideoNode, clip_b: vs.VideoNode, frames: int, mark=False,
     return sum(pairs, next(pairs))
 
 
-def stack_compare(*clips: vs.VideoNode, width=None, height=None, stack_vertical=False):
+def stack_compare(*clips: vs.VideoNode, width: int = None, height: int = None,
+                  stack_vertical: bool = False) -> vs.VideoNode:
     """
     A simple wrapper that allows you to compare two clips by stacking them.
     You can stack an infinite amount of clips.
-
+    
     Best to use when trying to match two sources frame-accurately, however by setting height to the source's
     height (or None), it can be used for comparing frames.
+    
+    Shorthand for this function is 'scomp'.
 
-    Shorthand for this function is "scomp".
+    :param clips: vs.VideoNode:
+    :param width: int:  (Default value = None)
+    :param height: int:  (Default value = None)
+    :param stack_vertical: bool:  (Default value = False)
+    :returns: vs.VideoNode clip
+
     """
     if len(set([c.format.id for c in clips])) != 1:
         raise ValueError('stack_compare: The format of every clip must be equal')
 
     if height is None:
-        height = vsutil.fallback(height, clips[0].height)
+        height = fallback(height, clips[0].height)
     if width is None:
-        width = vsutil.get_w(height, aspect_ratio=clips[0].width / clips[0].height)
+        width = get_w(height, aspect_ratio=clips[0].width / clips[0].height)
 
     clips = [c.resize.Bicubic(width, height) for c in clips]
     return core.std.StackVertical(clips) if stack_vertical else core.std.StackHorizontal(clips)
 
 
-def conditional_descale(src, height, b=1/3, c=1/3, threshold=0.003, w2x=False):
+def conditional_descale(src: vs.VideoNode, height: int, b: float = 1 / 3, c: float = 1 / 3, threshold: float = 0.003,
+                        w2x: bool = False) -> vs.VideoNode:
     """
-
-        Descales and reupscales a clip. If the difference exceeds the threshold, the frame will not be descaled.
+    Descales and reupscales a clip. If the difference exceeds the threshold, the frame will not be descaled.
         If it does not exceed the threshold, the frame will upscaled using either nnedi3_rpow2 or waifu2x-caffe.
-
+    
         Useful for bad BDs that have additional post-processing done on some scenes, rather than all of them.
-
+    
         Currently only works with bicubic, and has no native 1080p masking.
         Consider scenefiltering OP/EDs with a different descale function instead.
-
+    
         The code for _get_error was mostly taken from kageru's Made in Abyss script.
         Special thanks to Lypheo for holding my hand as this was written.
-    """
-    import functools
-    import fvsfunc as fvf  # https://github.com/Irrational-Encoding-Wizardry/fvsfunc
 
-    if vsutil.get_depth(src) != 32:
-        src = fvf.Depth(src, 32)
+    :param src: vs.VideoNode: 
+    :param height: int: 
+    :param b: float:  (Default value = 1 / 3)
+    :param c: float:  (Default value = 1 / 3)
+    :param threshold: float:  (Default value = 0.003)
+    :param w2x: bool:  (Default value = False)
+    :returns: vs.VideoNode clip
+
+    """
+
+    def _get_error(src, height, b, c):
+        descale = core.descale.Debicubic(src, get_w(height), height, b=b, c=c)
+        upscale = core.resize.Bicubic(descale, src.width, src.height, filter_param_a=b, filter_param_b=c)
+        diff = core.std.PlaneStats(upscale, src)
+        return descale, diff
+
+    def _diff(n, f, src, descaled, threshold, w2x):
+        if f.props.PlaneStatsDiff > threshold:
+            return src
+        else:
+            if w2x:
+                return core.caffe.Waifu2x(descaled, noise=-1, scale=2, model=6, cudnn=True, processor=0,
+                                          tta=False).resize.Bicubic(src.width, src.height, format=src.format)
+            else:
+                return nnedi3_rpow2(descaled).resize.Bicubic(src.width, src.height, format=src.format)
+
+    if get_depth(src) != 32:
+        src = fvf.Depth(src, 32, dither_type='none')
     y, u, v = kgf.split(src)
     descale = _get_error(y, height=height, b=b, c=c)
-    eval = core.std.FrameEval(src, functools.partial(_diff, src=src, descaled=descale[0], threshold=threshold, w2x=w2x), descale[1])
-    return kgf.join([eval, u, v])
+    f_eval = core.std.FrameEval(src,
+                                partial(_diff, src=src, descaled=descale[0], threshold=threshold, w2x=w2x),
+                                descale[1])
+    return kgf.join([f_eval, u, v])
 
 
-def _get_error(src, height, b, c):
-    descale = core.descale.Debicubic(src, vsutil.get_w(height), height, b=b, c=c)
-    upscale = core.resize.Bicubic(descale, src.width, src.height, filter_param_a=b, filter_param_b=c)
-    diff = core.std.PlaneStats(upscale, src)
-    return descale, diff
-
-
-def _diff(n, f, src, descaled, threshold=0.003, w2x=False):
-    from nnedi3_rpow2 import nnedi3_rpow2 # https://github.com/darealshinji/vapoursynth-plugins/blob/master/scripts/nnedi3_rpow2.py
-
-    if f.props.PlaneStatsDiff > threshold:
-        return src
-    else:
-        if w2x:
-            return core.caffe.Waifu2x(descaled, noise=-1, scale=2, model=6, cudnn=True, processor=0, tta=False).resize.Bicubic(src.width, src.height, format=src.format)
-        else:
-            return nnedi3_rpow2(descaled).resize.Bicubic(src.width, src.height, format=src.format)
-
-
-def transpose_aa(clip: vs.VideoNode, eedi3=False):
+def transpose_aa(clip: vs.VideoNode, eedi3: bool = False) -> vs.VideoNode:
     """
     Function written by Zastin and modified by me.
     Performs anti-aliasing over a clip by using nnedi3, transposing, using nnedi3 again, and transposing a final time.
     This results in overall stronger aliasing.
     Useful for shows like Yuru Camp with bad lineart problems.
+    
+    If eedi3=False, it will use Nnedi3 instead.
 
-    If Eedi3=False, it will use Nnedi3 instead.
+    :param clip: vs.VideoNode: 
+    :param eedi3: bool:  (Default value = False)
+    :returns: vs.VideoNode clip
+
     """
-    srcY = vsutil.get_y(clip)
+    src_y = get_y(clip)
     height, width = clip.height, clip.width
 
     if eedi3:
-        def aa(srcY):
-            srcY = srcY.std.Transpose()
-            srcY = srcY.eedi3m.EEDI3(0, 1, 0, 0.5, 0.2)
-            srcY = srcY.znedi3.nnedi3(1, 0, 0, 3, 4, 2)
-            srcY = srcY.resize.Spline36(height, width, src_top=.5)
-            srcY = srcY.std.Transpose()
-            srcY = srcY.eedi3m.EEDI3(0, 1, 0, 0.5, 0.2)
-            srcY = srcY.znedi3.nnedi3(1, 0, 0, 3, 4, 2)
-            srcY = srcY.resize.Spline36(width, height, src_top=.5)
-            return srcY
+        def _aa(src_y):
+            src_y = src_y.std.Transpose()
+            src_y = src_y.eedi3m.EEDI3(0, 1, 0, 0.5, 0.2)
+            src_y = src_y.znedi3.nnedi3(1, 0, 0, 3, 4, 2)
+            src_y = src_y.resize.Spline36(height, width, src_top=.5)
+            src_y = src_y.std.Transpose()
+            src_y = src_y.eedi3m.EEDI3(0, 1, 0, 0.5, 0.2)
+            src_y = src_y.znedi3.nnedi3(1, 0, 0, 3, 4, 2)
+            src_y = src_y.resize.Spline36(width, height, src_top=.5)
+            return src_y
     else:
-        def aa(srcY):
-            srcY = srcY.std.Transpose()
-            srcY = srcY.nnedi3.nnedi3(0, 1, 0, 3, 3, 2)
-            srcY = srcY.nnedi3.nnedi3(1, 0, 0, 3, 3, 2)
-            srcY = srcY.resize.Spline36(height, width, src_top=.5)
-            srcY = srcY.std.Transpose()
-            srcY = srcY.nnedi3.nnedi3(0, 1, 0, 3, 3, 2)
-            srcY = srcY.nnedi3.nnedi3(1, 0, 0, 3, 3, 2)
-            srcY = srcY.resize.Spline36(width, height, src_top=.5)
-            return srcY
+        def _aa(src_y):
+            src_y = src_y.std.Transpose()
+            src_y = src_y.nnedi3.nnedi3(0, 1, 0, 3, 3, 2)
+            src_y = src_y.nnedi3.nnedi3(1, 0, 0, 3, 3, 2)
+            src_y = src_y.resize.Spline36(height, width, src_top=.5)
+            src_y = src_y.std.Transpose()
+            src_y = src_y.nnedi3.nnedi3(0, 1, 0, 3, 3, 2)
+            src_y = src_y.nnedi3.nnedi3(1, 0, 0, 3, 3, 2)
+            src_y = src_y.resize.Spline36(width, height, src_top=.5)
+            return src_y
 
-    def csharp(flt, src):
+    def _csharp(flt, src):
         blur = core.std.Convolution(flt, [1] * 9)
         return core.std.Expr([flt, src, blur], 'x y < x x + z - x max y min x x + z - x min y max ?')
 
-    aaclip = aa(srcY)
-    aaclip = csharp(aaclip, srcY).rgvs.Repair(srcY, 13)
+    aaclip = _aa(src_y)
+    aaclip = _csharp(aaclip, src_y).rgvs.Repair(src_y, 13)
 
     return aaclip if clip.format.color_family is vs.GRAY else core.std.ShufflePlanes([aaclip, clip], [0, 1, 2], vs.YUV)
 
 
-def NnEedi3(clip: vs.VideoNode, mask=None, strong_mask=False, show_mask=False, opencl=False, strength=1, alpha=0.25, beta=0.5, gamma=40, nrad=2, mdis=20, nsize=3, nns=3, qual=1):
+def nneedi3_clamp(clip: vs.VideoNode, mask=None, strong_mask: bool = False, show_mask: bool = False,
+                  opencl: bool = False, strength=1, alpha: float = 0.25,
+                  beta: float = 0.5, gamma=40, nrad=2, mdis=20, nsize=3, nns=3, qual=1) -> vs.VideoNode:
     """
     Script written by Zastin. What it does is clamp the "change" done by eedi3 to the "change" of nnedi3.
     This should fix every issue created by eedi3. For example: https://i.imgur.com/hYVhetS.jpg
-
+    
     "mask" allows for you to use your own mask.
     "strong_mask" uses a binarized kgf.retinex_edgemask to replace more lineart with nnedi3.
-    """
-    import vsTAAmbk as taa  # https://github.com/HomeOfVapourSynthEvolution/vsTAAmbk
 
+    :param clip: vs.VideoNode: 
+    :param mask:  (Default value = None)
+    :param strong_mask: bool:  (Default value = False)
+    :param show_mask: bool:  (Default value = False)
+    :param opencl: bool:  (Default value = False)
+    :param strength:  (Default value = 1)
+    :param alpha: float:  (Default value = 0.25)
+    :param beta: float:  (Default value = 0.5)
+    :param gamma:  (Default value = 40)
+    :param nrad:  (Default value = 2)
+    :param mdis:  (Default value = 20)
+    :param nsize:  (Default value = 3)
+    :param nns:  (Default value = 3)
+    :param qual:  (Default value = 1)
+    :returns: vs.VideoNode clip
+
+    """
     bits = clip.format.bits_per_sample - 8
     thr = strength * (1 >> bits)
-    strong = taa.TAAmbk(clip, aatype='Eedi3', alpha=alpha, beta=beta, gamma=gamma, nrad=nrad, mdis=mdis, mtype=0, opencl=opencl)
-    weak = taa.TAAmbk(clip, aatype='Nnedi3', nsize=nsize, nns=nns, qual=qual, mtype=0, opencl=opencl)
-    expr = 'x z - y z - * 0 < y x y {l} + min y {l} - max ?'.format(l=thr)
+    strong = TAAmbk(clip, aatype='Eedi3', alpha=alpha, beta=beta, gamma=gamma, nrad=nrad, mdis=mdis, mtype=0,
+                    opencl=opencl)
+    weak = TAAmbk(clip, aatype='Nnedi3', nsize=nsize, nns=nns, qual=qual, mtype=0, opencl=opencl)
+    expr = 'x z - y z - * 0 < y x y {0} + min y {0} - max ?'.format(thr)
     if clip.format.num_planes > 1:
         expr = [expr, '']
     aa = core.std.Expr([strong, weak, clip], expr)
@@ -165,8 +229,9 @@ def NnEedi3(clip: vs.VideoNode, mask=None, strong_mask=False, show_mask=False, o
         mask = kgf.retinex_edgemask(clip, 1).std.Binarize()
         merged = clip.std.MaskedMerge(aa, mask, planes=0)
     else:
-        mask = clip.std.Prewitt(planes=0).std.Binarize(planes=0).std.Maximum(planes=0).std.Convolution([1]*9, planes=0)
-        mask = vsutil.get_y(mask)
+        mask = clip.std.Prewitt(planes=0).std.Binarize(planes=0).std.Maximum(planes=0).std.Convolution([1] * 9,
+                                                                                                       planes=0)
+        mask = get_y(mask)
         merged = clip.std.MaskedMerge(aa, mask, planes=0)
 
     if show_mask:
@@ -175,101 +240,137 @@ def NnEedi3(clip: vs.VideoNode, mask=None, strong_mask=False, show_mask=False, o
     return merged if clip.format.color_family == vs.GRAY else core.std.ShufflePlanes([merged, clip], [0, 1, 2], vs.YUV)
 
 
-def quick_denoise(src: vs.VideoNode, sigma=4, cmode='knlm', ref=None, **kwargs):
+def quick_denoise(src: vs.VideoNode, sigma=4, cmode='knlm', ref: vs.VideoNode = None, **kwargs) -> vs.VideoNode:
     """
-        A rewrite of my old 'quick_denoise'. I still hate it, but whatever.
+    A rewrite of my old 'quick_denoise'. I still hate it, but whatever.
         This will probably be removed in a future commit.
-
+    
         This wrapper is used to denoise both the luma and chroma using various denoisers of your choosing.
-        If you wish to use just one denoiser, you're probably better off using that specific filter rather than this wrapper.
-
+        If you wish to use just one denoiser,
+        you're probably better off using that specific filter rather than this wrapper.
+    
         Chroma Modes (cmode):
             1 - Use knlmeans for denoising the chroma
             2 - Use tnlmeans for denoising the chroma
             3 - Use dfttest for denoising the chroma
             4 - Use SMDegrain for denoising the chroma
-
+    
         BM3D is used for denoising the luma. Denoising strenght is set with "sigma".
-
+    
         Special thanks to kageru for helping me out with some ideas and pointers.
-    """
-    import havsfunc as hvf  # https://github.com/HomeOfVapourSynthEvolution/havsfunc
-    import mvsfunc as mvf  # https://github.com/HomeOfVapourSynthEvolution/mvsfunc
 
-    Y, U, V = kgf.split(src)
+    :param src: vs.VideoNode: 
+    :param sigma:  (Default value = 4)
+    :param cmode:  (Default value = 'knlm')
+    :param ref: vs.VideoNode:  (Default value = None)
+    :param kwargs:
+    :returns: vs.VideoNode clip
+
+    """
+
+    y, u, v = kgf.split(src)
 
     if cmode in [1, 'knlm']:
-        denU = U.knlm.KNLMeansCL(d=3, a=2, **kwargs)
-        denV = V.knlm.KNLMeansCL(d=3, a=2, **kwargs)
+        den_u = u.knlm.KNLMeansCL(d=3, a=2, **kwargs)
+        den_v = v.knlm.KNLMeansCL(d=3, a=2, **kwargs)
     elif cmode in [2, 'tnlm']:
-        denU = U.tnlm.TNLMeans(ax=2, ay=2, az=2, **kwargs)
-        denV = V.tnlm.TNLMeans(ax=2, ay=2, az=2, **kwargs)
+        den_u = u.tnlm.TNLMeans(ax=2, ay=2, az=2, **kwargs)
+        den_v = v.tnlm.TNLMeans(ax=2, ay=2, az=2, **kwargs)
     elif cmode in [3, 'dft']:
-        denU = U.dfttest.DFTTest(sosize=sbsize*0.75, **kwargs)
-        denV = V.dfttest.DFTTest(sosize=sbsize*0.75, **kwargs)
+        if 'sbsize' in kwargs:
+            den_u = u.dfttest.DFTTest(sosize=kwargs['sbsize'] * 0.75, **kwargs)
+            den_v = v.dfttest.DFTTest(sosize=kwargs['sbsize'] * 0.75, **kwargs)
+        else:
+            raise ValueError('quick_denoise: \'sbsize\' not specified')
     elif cmode in [4, 'smd']:
-        denU = hvf.SMDegrain(U, prefilter=3, **kwargs)
-        denV = hvf.SMDegrain(V, prefilter=3, **kwargs)
+        den_u = hvf.SMDegrain(u, prefilter=3, **kwargs)
+        den_v = hvf.SMDegrain(v, prefilter=3, **kwargs)
     else:
         raise ValueError('quick_denoise: unknown mode')
 
-    denY = mvf.BM3D(Y, sigma=sigma, psample=0, radius1=1, ref=ref)
-    return core.std.ShufflePlanes([denY, denU, denV], 0, vs.YUV)
+    den_y = mvf.BM3D(y, sigma=sigma, psample=0, radius1=1, ref=ref)
+    return core.std.ShufflePlanes([den_y, den_u, den_v], 0, vs.YUV)
 
 
-def stack_planes(src, stack_vertical=False):
+def stack_planes(src: vs.VideoNode, stack_vertical: bool = False) -> vs.VideoNode:
     """
     Stacks the planes of a clip.
+
+    :param src: vs.VideoNode: 
+    :param stack_vertical: bool:  (Default value = False)
+    :returns: vs.VideoNode clip
+
     """
-    Y, U, V = kgf.split(src)
-    subsampling = vsutil.get_subsampling(src)
+    y, u, v = kgf.split(src)
+    subsampling = get_subsampling(src)
 
     if subsampling is "420":
         if stack_vertical:
-            UV = core.std.StackHorizontal([U, V])
-            return core.std.StackVertical([Y, UV])
+            u_v = core.std.StackHorizontal([u, v])
+            return core.std.StackVertical([y, u_v])
         else:
-            UV = core.std.StackVertical([U, V])
-            return core.std.StackHorizontal([Y, UV])
+            u_v = core.std.StackVertical([u, v])
+            return core.std.StackHorizontal([y, u_v])
     elif subsampling is "444":
-         return core.std.StackVertical([Y, U, V]) if stack_vertical else core.std.StackHorizontal([Y, U, V])
+        return core.std.StackVertical([y, u, v]) if stack_vertical else core.std.StackHorizontal([y, u, v])
 
 
-def test_descale(src, height, kernel='bicubic', b=1/3, c=1/3, taps=4):
+# TODO: fix test_descale ?
+
+def test_descale(src: vs.VideoNode, height: int, kernel: str = 'bicubic', b: float = 1 / 3, c: float = 1 / 3,
+                 taps: int = 4) -> vs.VideoNode:
     """
     Generic function to test descales with.
     Descales and reupscales a given clip, allowing you to compare the two easily.
-
+    
     When comparing, it is recommended to do atleast a 4x zoom using Nearest Neighbor.
-    I also suggest using "compare", as that will make comparison a lot easier.
+    I also suggest using 'compare', as that will make comparison a lot easier.
+
+    :param src: vs.VideoNode: 
+    :param height: int: 
+    :param kernel: str:  (Default value = 'bicubic')
+    :param b: float:  (Default value = 1 / 3)
+    :param c: float:  (Default value = 1 / 3)
+    :param taps: int:  (Default value = 4)
+    :returns: vs.VideoNode clip
+
     """
     y, u, v = kgf.split(src)
     if kernel is 'bicubic':
-        descaled = core.descale.Debicubic(y, vsutil.get_w(height), height, b=b, c=c)
+        descaled = core.descale.Debicubic(y, get_w(height), height, b=b, c=c)
         upscaled = core.resize.Bicubic(descaled, y.width, y.height, filter_param_a=b, filter_param_b=c)
     elif kernel is 'bilinear':
-        descaled = core.descale.Debilinear(y, vsutil.get_w(height), height)
-        upscaled = core.resize.Bilinear(descaled, vsutil.get_w(height), height)
+        descaled = core.descale.Debilinear(y, get_w(height), height)
+        upscaled = core.resize.Bilinear(descaled, get_w(height), height)
     elif kernel is 'lanczos':
-        descaled = core.descale.Delanczos(y, vsutil.get_w(height), height, taps=taps)
+        descaled = core.descale.Delanczos(y, get_w(height), height, taps=taps)
         upscaled = core.resize.Lanczos(descaled, y.width, y.height, filter_param_a=taps)
     elif kernel is 'spline16':
-        descaled = core.descale.Despline16(y, width, height)
-        upscaled = core.resize.Spline16(descaled, vsutil.get_w(height), height)
+        descaled = core.descale.Despline16(y, get_w(height), height)
+        upscaled = core.resize.Spline16(descaled, get_w(height), height)
     elif kernel is 'spline36':
-        descaled = core.descale.Despline36(y, width, height)
-        upscaled = core.resize.Spline36(descaled, vsutil.get_w(height), height)
+        descaled = core.descale.Despline36(y, get_w(height), height)
+        upscaled = core.resize.Spline36(descaled, get_w(height), height)
     else:
         raise ValueError('test_descale: unknown kernel')
 
     return kgf.join([upscaled, u, v])
 
 
-def source(file: str, force_lsmas=False, src=None, fpsnum=None, fpsden=None) -> vs.VideoNode:
+def source(file: str, force_lsmas: bool = False, src=None, fpsnum: int = None, fpsden: int = None) -> vs.VideoNode:
     """
     Generic clip import function.
     Automatically determines if ffms2 or L-SMASH should be used to import a clip, but L-SMASH can be forced.
-    It also automatically determines if an image has been imported. You can set its fps using "fpsnum" and "fpsden", or using a reference clip with "src".
+    It also automatically determines if an image has been imported.
+    You can set its fps using "fpsnum" and "fpsden", or using a reference clip with "src".
+
+    :param file: str: 
+    :param force_lsmas: bool:  (Default value = False)
+    :param src:  (Default value = None)
+    :param fpsnum: int:  (Default value = None)
+    :param fpsden: int:  (Default value = None)
+    :returns: vs.VideoNode clip
+
     """
     if file.startswith("file:///"):
         file = file[8::]
@@ -279,7 +380,7 @@ def source(file: str, force_lsmas=False, src=None, fpsnum=None, fpsden=None) -> 
 
     if file.endswith(".d2v"):
         clip = core.d2v.Source(file)
-    elif vsutil.is_image(file):
+    elif is_image(file):
         clip = core.imwri.Read(file)
         if src is not None:
             clip = core.std.AssumeFPS(clip, fpsnum=src.fps.numerator, fpsden=src.fps.denominator)
@@ -294,10 +395,10 @@ def source(file: str, force_lsmas=False, src=None, fpsnum=None, fpsden=None) -> 
     return clip
 
 
-# Aliasses
+# Aliases
 src = source
 comp = compare
 scomp = stack_compare
 qden = quick_denoise
-denoise = quick_denoise # (backwards compatibility, will be removed later)
-
+denoise = quick_denoise  # (backwards compatibility, will be removed later)
+NnEedi3 = nneedi3_clamp  # for backwards compatibility

--- a/lvsfunc.py
+++ b/lvsfunc.py
@@ -228,7 +228,7 @@ def quick_denoise(src: vs.VideoNode, sigma=4, cmode='knlm', ref: vs.VideoNode = 
     :param cmode:  Chroma modes:
                      1 - Use knlmeans for denoising the chroma (default)
                      2 - Use tnlmeans for denoising the chroma
-                     3 - Use dfttest for denoising the chroma
+                     3 - Use dfttest for denoising the chroma (requires setting 'sbsize' in kwargs)
                      4 - Use SMDegrain for denoising the chroma
     :param ref: vs.VideoNode:  Optional reference clip to replace BM3D's basic estimate. (Default value = None)
 

--- a/lvsfunc.py
+++ b/lvsfunc.py
@@ -24,23 +24,15 @@ core = vs.core
 
 # TODO: Write function that only masks px of a certain color/threshold of colors
 
-
 def compare(clip_a: vs.VideoNode, clip_b: vs.VideoNode, *frames: int, mark: bool = False, mark_a: str = ' Clip A ',
             mark_b: str = ' Clip B ',
             fontsize: int = 57) -> vs.VideoNode:
     """
     Allows for the same frames from two different clips to be compared by putting them next to each other in a list.
-    
+
     Shorthand for this function is "comp".
 
-    :param clip_a: vs.VideoNode: 
-    :param clip_b: vs.VideoNode: 
-    :param frames: int:
-    :param mark: bool:  (Default value = False)
-    :param mark_a: str:  (Default value = ' Clip A ')
-    :param mark_b: str:  (Default value = ' Clip B ')
-    :param fontsize: int:  (Default value = 57)
-    :returns: vs.VideoNode clip
+    :param mark: bool:  Whether or not to label the clips in top left. (Default value = False)
 
     """
     if clip_a.format.id != clip_b.format.id:
@@ -61,17 +53,11 @@ def stack_compare(*clips: vs.VideoNode, width: int = None, height: int = None,
     """
     A simple wrapper that allows you to compare two clips by stacking them.
     You can stack an infinite amount of clips.
-    
+
     Best to use when trying to match two sources frame-accurately, however by setting height to the source's
     height (or None), it can be used for comparing frames.
-    
-    Shorthand for this function is 'scomp'.
 
-    :param clips: vs.VideoNode:
-    :param width: int:  (Default value = None)
-    :param height: int:  (Default value = None)
-    :param stack_vertical: bool:  (Default value = False)
-    :returns: vs.VideoNode clip
+    Shorthand for this function is 'scomp'.
 
     """
     if len(set([c.format.id for c in clips])) != 1:
@@ -90,23 +76,18 @@ def conditional_descale(src: vs.VideoNode, height: int, b: float = 1 / 3, c: flo
                         w2x: bool = False) -> vs.VideoNode:
     """
     Descales and reupscales a clip. If the difference exceeds the threshold, the frame will not be descaled.
-        If it does not exceed the threshold, the frame will upscaled using either nnedi3_rpow2 or waifu2x-caffe.
-    
-        Useful for bad BDs that have additional post-processing done on some scenes, rather than all of them.
-    
-        Currently only works with bicubic, and has no native 1080p masking.
-        Consider scenefiltering OP/EDs with a different descale function instead.
-    
-        The code for _get_error was mostly taken from kageru's Made in Abyss script.
-        Special thanks to Lypheo for holding my hand as this was written.
+    If it does not exceed the threshold, the frame will upscaled using either nnedi3_rpow2 or waifu2x-caffe.
 
-    :param src: vs.VideoNode: 
-    :param height: int: 
-    :param b: float:  (Default value = 1 / 3)
-    :param c: float:  (Default value = 1 / 3)
-    :param threshold: float:  (Default value = 0.003)
-    :param w2x: bool:  (Default value = False)
-    :returns: vs.VideoNode clip
+    Useful for bad BDs that have additional post-processing done on some scenes, rather than all of them.
+
+    Currently only works with bicubic, and has no native 1080p masking.
+    Consider scenefiltering OP/EDs with a different descale function instead.
+
+    The code for _get_error was mostly taken from kageru's Made in Abyss script.
+    Special thanks to Lypheo for holding my hand as this was written.
+
+    :param height: int:  Target descaled height.
+    :param w2x: bool:  Whether or not to use waifu2x-caffe upscaling. (Default value = False)
 
     """
 
@@ -139,15 +120,11 @@ def conditional_descale(src: vs.VideoNode, height: int, b: float = 1 / 3, c: flo
 def transpose_aa(clip: vs.VideoNode, eedi3: bool = False) -> vs.VideoNode:
     """
     Function written by Zastin and modified by me.
-    Performs anti-aliasing over a clip by using nnedi3, transposing, using nnedi3 again, and transposing a final time.
-    This results in overall stronger aliasing.
+    Performs anti-aliasing over a clip by using Nnedi3, transposing, using Nnedi3 again, and transposing a final time.
+    This results in overall stronger anti-aliasing.
     Useful for shows like Yuru Camp with bad lineart problems.
-    
-    If eedi3=False, it will use Nnedi3 instead.
 
-    :param clip: vs.VideoNode: 
-    :param eedi3: bool:  (Default value = False)
-    :returns: vs.VideoNode clip
+    :param eedi3: bool:  When true, uses eedi3 instead. (Default value = False)
 
     """
     src_y = get_y(clip)
@@ -192,15 +169,12 @@ def nneedi3_clamp(clip: vs.VideoNode, mask=None, strong_mask: bool = False, show
     """
     Script written by Zastin. What it does is clamp the "change" done by eedi3 to the "change" of nnedi3.
     This should fix every issue created by eedi3. For example: https://i.imgur.com/hYVhetS.jpg
-    
-    "mask" allows for you to use your own mask.
-    "strong_mask" uses a binarized kgf.retinex_edgemask to replace more lineart with nnedi3.
 
-    :param clip: vs.VideoNode: 
-    :param mask:  (Default value = None)
-    :param strong_mask: bool:  (Default value = False)
-    :param show_mask: bool:  (Default value = False)
-    :param opencl: bool:  (Default value = False)
+    :param mask:  Allows for user to use their own mask. (Default value = None)
+    :param strong_mask: bool:  Whether or not to use a binarized kgf.retinex_edgemask
+                               to replace more lineart with nnedi3. (Default value = False)
+    :param show_mask: bool:  Whether or not to return the mask instead of the processed clip. (Default value = False)
+    :param opencl: bool:  Allows TAAmbk to use opencl acceleration when anti-aliasing. (Default value = False)
     :param strength:  (Default value = 1)
     :param alpha: float:  (Default value = 0.25)
     :param beta: float:  (Default value = 0.5)
@@ -210,7 +184,6 @@ def nneedi3_clamp(clip: vs.VideoNode, mask=None, strong_mask: bool = False, show
     :param nsize:  (Default value = 3)
     :param nns:  (Default value = 3)
     :param qual:  (Default value = 1)
-    :returns: vs.VideoNode clip
 
     """
     bits = clip.format.bits_per_sample - 8
@@ -243,28 +216,23 @@ def nneedi3_clamp(clip: vs.VideoNode, mask=None, strong_mask: bool = False, show
 def quick_denoise(src: vs.VideoNode, sigma=4, cmode='knlm', ref: vs.VideoNode = None, **kwargs) -> vs.VideoNode:
     """
     A rewrite of my old 'quick_denoise'. I still hate it, but whatever.
-        This will probably be removed in a future commit.
-    
-        This wrapper is used to denoise both the luma and chroma using various denoisers of your choosing.
-        If you wish to use just one denoiser,
-        you're probably better off using that specific filter rather than this wrapper.
-    
-        Chroma Modes (cmode):
-            1 - Use knlmeans for denoising the chroma
-            2 - Use tnlmeans for denoising the chroma
-            3 - Use dfttest for denoising the chroma
-            4 - Use SMDegrain for denoising the chroma
-    
-        BM3D is used for denoising the luma. Denoising strenght is set with "sigma".
-    
-        Special thanks to kageru for helping me out with some ideas and pointers.
+    This will probably be removed in a future commit.
 
-    :param src: vs.VideoNode: 
-    :param sigma:  (Default value = 4)
-    :param cmode:  (Default value = 'knlm')
-    :param ref: vs.VideoNode:  (Default value = None)
-    :param kwargs:
-    :returns: vs.VideoNode clip
+    This wrapper is used to denoise both the luma and chroma using various denoisers of your choosing.
+    If you wish to use just one denoiser,
+    you're probably better off using that specific filter rather than this wrapper.
+
+    BM3D is used for denoising the luma.
+
+    Special thanks to kageru for helping me out with some ideas and pointers.
+
+    :param sigma:  Denoising strength for BM3D. (Default value = 4)
+    :param cmode:  Chroma modes:
+                     1 - Use knlmeans for denoising the chroma (default)
+                     2 - Use tnlmeans for denoising the chroma
+                     3 - Use dfttest for denoising the chroma
+                     4 - Use SMDegrain for denoising the chroma
+    :param ref: vs.VideoNode:  Optional reference clip to replace BM3D's basic estimate. (Default value = None)
 
     """
 
@@ -293,14 +261,8 @@ def quick_denoise(src: vs.VideoNode, sigma=4, cmode='knlm', ref: vs.VideoNode = 
 
 
 def stack_planes(src: vs.VideoNode, stack_vertical: bool = False) -> vs.VideoNode:
-    """
-    Stacks the planes of a clip.
+    """Stacks the planes of a clip."""
 
-    :param src: vs.VideoNode: 
-    :param stack_vertical: bool:  (Default value = False)
-    :returns: vs.VideoNode clip
-
-    """
     y, u, v = kgf.split(src)
     subsampling = get_subsampling(src)
 
@@ -322,17 +284,15 @@ def test_descale(src: vs.VideoNode, height: int, kernel: str = 'bicubic', b: flo
     """
     Generic function to test descales with.
     Descales and reupscales a given clip, allowing you to compare the two easily.
-    
+
     When comparing, it is recommended to do atleast a 4x zoom using Nearest Neighbor.
     I also suggest using 'compare', as that will make comparison a lot easier.
 
-    :param src: vs.VideoNode: 
-    :param height: int: 
-    :param kernel: str:  (Default value = 'bicubic')
-    :param b: float:  (Default value = 1 / 3)
-    :param c: float:  (Default value = 1 / 3)
-    :param taps: int:  (Default value = 4)
-    :returns: vs.VideoNode clip
+    :param height: int:  Target descaled height.
+    :param kernel: str:  Descale kernel - 'bicubic'(default), 'bilinear', 'lanczos', 'spline16', or 'spline36'
+    :param b: float:  B-param for bicubic kernel. (Default value = 1 / 3)
+    :param c: float:  C-param for bicubic kernel. (Default value = 1 / 3)
+    :param taps: int:  Taps param for lanczos kernel. (Default value = 4)
 
     """
     y, u, v = kgf.split(src)
@@ -364,12 +324,7 @@ def source(file: str, force_lsmas: bool = False, src=None, fpsnum: int = None, f
     It also automatically determines if an image has been imported.
     You can set its fps using "fpsnum" and "fpsden", or using a reference clip with "src".
 
-    :param file: str: 
-    :param force_lsmas: bool:  (Default value = False)
-    :param src:  (Default value = None)
-    :param fpsnum: int:  (Default value = None)
-    :param fpsden: int:  (Default value = None)
-    :returns: vs.VideoNode clip
+    :param file: str:  OS absolute file location.
 
     """
     if file.startswith("file:///"):


### PR DESCRIPTION
The only function not working is test_descale (but this commit is not the thing that breaks it):
```
vapoursynth.Error: Descale: Constant format GrayS, RGBS, and YUV444PS are the only supported input formats.
```
This should be replaced with https://github.com/EleonoreMizo/fmtconv

TODO:
- [x] actually explain each argument in the docstrings (although some are self-explanatory)
- [x] **re-do README.md to reflect these changes**
  - [x] add _clamp to readme
- [x] more thorough testing with weird clips/arguments combos that might break

For future reference, on another PR - TODO:
- [ ] update information on <http://vsdb.top/>
- [ ] remove unnecessary functions or split into multiple scripts (regarding kageru's blog post about xxxfuncs)

Also, I suggest switching from using your two compare functions to this https://gist.github.com/OrangeChannel/c702baf34b4d4e4383c8209b8eadd8fb . The alias `lcomp` mimics your function with cleaner syntax: `vscompare.lcomp(17, 19, bluray=bd, tv=tv)`.