### PR TITLE
add replace_ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ This function offers the following (sorted by category):</br>
 | 9 | **Antialiasing** | transpose_aa | | AA's a clip by transposing it | clip, eedi3 |
 | 10 | **Antialiasing** | upscaled_sraa | | AA's through a upscaled single-rate AA. Can also be used for scaling | clip, rfactor, rep, h, sharp_downscale |
 | 11 | **Deinterlacing** | deblend | | Deblends a clip in an AABBA pattern and returns a decimated clip | clip, rep |
-| 11 | **Deinterlacing** | decomb | | Gets rid of the combing on an interlaced/telecined source | clip, TFF, decimate, vinv, sharp, dir, rep |
-| 12 | **Deinterlacing** | dir_deshimmer | | Directional deshimmering function | clip, TFF, dh, transpose, show_mask |
-| 13 | **Deinterlacing** | dir_unsharp | | Directional deshimmering function | clip, strength, dir, h |
-| 14 | **Denoising and Debanding** | quick_denoise | qden | Quick denoising function, allowing for different denoisers to be set for the chroma | clip, sigma, cmode, ref, **kwargs |
-| 15 | **Masking, Limiting, and Color Handling** | edgefixer | | A wrapper for ContinuityFixer that fixes under- and overshoot | clip, left, right, top, down, radius, full_range |
-| 16 | **Masking, Limiting, and Color Handling** | fix_cr_tint | | Does a rough fix to the green tint present in Crunchyroll encodes | clip, value |
-| 17 | **Masking, Limiting, and Color Handling** | limit_dark | | Replaces frames in a clip with a filtered clip when the frame's darkness exceeds the threshold | clip, filtered, threshold, threshold_range |
+| 12 | **Deinterlacing** | decomb | | Gets rid of the combing on an interlaced/telecined source | clip, TFF, decimate, vinv, sharp, dir, rep |
+| 13 | **Deinterlacing** | dir_deshimmer | | Directional deshimmering function | clip, TFF, dh, transpose, show_mask |
+| 14 | **Deinterlacing** | dir_unsharp | | Directional deshimmering function | clip, strength, dir, h |
+| 15 | **Denoising and Debanding** | quick_denoise | qden | Quick denoising function, allowing for different denoisers to be set for the chroma | clip, sigma, cmode, ref, **kwargs |
+| 16 | **Masking, Limiting, and Color Handling** | edgefixer | | A wrapper for ContinuityFixer that fixes under- and overshoot | clip, left, right, top, down, radius, full_range |
+| 17 | **Masking, Limiting, and Color Handling** | fix_cr_tint | | Does a rough fix to the green tint present in Crunchyroll encodes | clip, value |
+| 18 | **Masking, Limiting, and Color Handling** | limit_dark | | Replaces frames in a clip with a filtered clip when the frame's darkness exceeds the threshold | clip, filtered, threshold, threshold_range |
 | 19 | **Masking, Limiting, and Color Handling** | wipe_row | | Simple function to wipe a row with a blank or given clip. | clip, secondary, width, height, offset_x, offset_y, width2, height2, offset_x2, offset_y2, show_mask |
-| 19 | **Miscellaneous** | source | src | Automatically determines how a clip or image should be imported | file, ref, force_lsmas, mpls, mpls_playlist, mpls_angle |
-| 20 | **Experimental** | smarter_descale | | An updated version of smart_descale, hence smart*er*_descale | src, resolutions, descaler, rescaler, upscaler, thr, rescale, to_src |
+| 20 | **Miscellaneous** | source | src | Automatically determines how a clip or image should be imported | file, ref, force_lsmas, mpls, mpls_playlist, mpls_angle |
+| 21 | **Miscellaneous** | replace_ranges | rfs | Replaces frame ranges in a clip with those from another clip | clip_a, clip_b, ranges |
+| 22 | **Experimental** | smarter_descale | | An updated version of smart_descale, hence smart*er*_descale | src, resolutions, descaler, rescaler, upscaler, thr, rescale, to_src |
 
 
 ## Requirements:

--- a/lvsfunc.py
+++ b/lvsfunc.py
@@ -17,7 +17,7 @@ from vsTAAmbk import TAAmbk                     # https://github.com/HomeOfVapou
 from vsutil import *                            # https://github.com/Irrational-Encoding-Wizardry/vsutil
 
 from collections import namedtuple
-from typing import Callable, List, Dict
+from typing import Callable, List, Dict, Union
 import math
 
 core = vs.core
@@ -63,6 +63,7 @@ core = vs.core
 
     Miscellaneous:
         - source (src)
+        - replace_ranges (rfs)
 """
 
 #### Comparison and Analysis Functions
@@ -958,6 +959,33 @@ def source(file: str, ref: vs.VideoNode = None,
     return clip
 
 
+def replace_ranges(clip_a: vs.VideoNode,
+                   clip_b: vs.VideoNode,
+                   ranges: List[Union[int, Tuple[int, int]]]) -> vs.VideoNode:
+    """
+    A replacement for ReplaceFramesSimple that uses ints and tuples rather than
+    a string.
+
+    :param clip_a: vs.VideoNode:                Original clip
+    :param clip_b: vs.VideoNode:                Replacement clip
+    :param ranges: List[Union[int, Tuple[int, int]]]: Ranges to replace clip_a (original clip)
+                                                      with clip_b (replacement clip).
+                                                      Integer values in the list
+                                                      indicate single frames,
+                                                      Tuple values indicate
+                                                      inclusive ranges.
+    """
+    funcname = "replace_ranges"
+    out = clip_a
+    for r in ranges:
+        if type(r) is tuple:
+            start, end = r
+            out = out[:start] + clip_b[start : end + 1] + out[end + 1 :]
+        else:
+            out = out[:r] + clip_b[r] + out[r + 1 :]
+    return out
+
+
 # Helper funcs
 
 def one_plane(clip: vs.VideoNode) -> bool:
@@ -992,3 +1020,4 @@ scomp = stack_compare
 qden = quick_denoise
 cond_desc = conditional_descale
 sraa = upscaled_sraa
+rfs = replace_ranges


### PR DESCRIPTION
Functions similarly to ReplaceFramesSimple but uses Python int and tuple rather than a text string.