### PR TITLE
scale: descale: add kernel_list

### DIFF
--- a/lvsfunc/scale.py
+++ b/lvsfunc/scale.py
@@ -166,7 +166,8 @@ def descale(clip: vs.VideoNode,
             = reupscale,
             width: Union[int, List[int], None] = None,
             height: Union[int, List[int]] = 720,
-            kernel_list: Union[kernels.Kernel, List[kernels.Kernel]] = kernels.Bicubic(b=0, c=1/2),            threshold: float = 0.0,
+            kernel_list: Union[kernels.Kernel, List[kernels.Kernel]] = kernels.Bicubic(b=0, c=1/2),
+            threshold: float = 0.0,
             mask: Callable[[vs.VideoNode, vs.VideoNode], vs.VideoNode]
             = detail_mask, src_left: float = 0.0, src_top: float = 0.0,
             show_mask: bool = False) -> vs.VideoNode:


### PR DESCRIPTION
I'd like a review to check my code and a reliable way to check the kernel used.
At the moment, it's bad and you can't really see what it is.

File used: Episode 06 of Kouya no Kotobuki no Hikoutai
```py
src = lvf.src('[BDMV] 荒野のコトブキ飛行隊 Blu-ray BOX/上巻/Vol.02/BDMV/STREAM/00004.m2ts')
kernels_list = [lvf.kernels.Bicubic(b=0, c=1/2),
                lvf.kernels.Bicubic(b=0, c=1)]
h = [842, 844]

descaled = lvf.scale.descale(src, upscaler=None, height=h, kernel_list=kernels_list)

descaled.text.FrameProps().set_output()
```
842p parts are in bicubic sharp and 844p in catmull

catmull part where I'm sure:
`[3653 3936] [4224 4537] [18919 18966] [19331 19550] [19599 19693] [19826 20310] [21701 21891] [25862 26052] [33722 34045]`