### PR TITLE
Remove alias declarations in modules, add mention of alias in docstrings

### DIFF
--- a/lvsfunc/aa.py
+++ b/lvsfunc/aa.py
@@ -139,6 +139,8 @@ def upscaled_sraa(clip: vs.VideoNode,
 
     Original function written by Zastin, heavily modified by LightArrowsEXE.
 
+    Alias for this function is `lvsfunc.sraa`.
+
     Dependencies: fmtconv, rgsf (optional: 32 bit clip), vapoursynth-eedi3, vapoursynth-nnedi3
 
     :param clip:            Input clip
@@ -189,7 +191,3 @@ def upscaled_sraa(clip: vs.VideoNode,
     if rep:
         scaled = util.pick_repair(scaled)(scaled, luma.resize.Spline36(w, h), rep)
     return scaled if clip.format.color_family is vs.GRAY else core.std.ShufflePlanes([scaled, clip], [0, 1, 2], vs.YUV)
-
-
-# Aliases:
-sraa = upscaled_sraa

--- a/lvsfunc/comparison.py
+++ b/lvsfunc/comparison.py
@@ -21,7 +21,7 @@ def compare(clip_a: vs.VideoNode, clip_b: vs.VideoNode,
     Clips are automatically resampled to 8 bit YUV -> RGB24 to emulate how a monitor shows the frame.
     This can be disabled by setting `disable_resample` to True.
 
-    Alias for this function is "comp".
+    Alias for this function is `lvsfunc.comp`.
 
     Dependencies: mvsfunc
 
@@ -79,7 +79,7 @@ def stack_compare(*clips: vs.VideoNode,
     Best to use when trying to match two sources frame-accurately, however by setting height to the source's
     height (or None), it can be used for comparing frames.
 
-    Alias for this function is 'scomp'.
+    Alias for this function is `lvsfunc.scomp`.
 
     :param clips:             Clips to compare
     :param make_diff:         Create and stack a diff (only works if two clips are given) (Default: False)
@@ -156,6 +156,8 @@ def tvbd_diff(tv: vs.VideoNode, bd: vs.VideoNode,
     Note that this might catch artifacting as differences!
     Make sure you verify every frame with your own eyes!
 
+    Alias for this function is `lvsfunc.diff`.
+
     :param tv:            TV clip
     :param bd:            BD clip
     :param thr:           Threshold, <= 1 uses PlaneStatsDiff, >1 uses Max/Min. Max is 128 (Default: 72)
@@ -194,9 +196,3 @@ def tvbd_diff(tv: vs.VideoNode, bd: vs.VideoNode,
 #       It should theoretically accept an infinite amount of clips
 #       and accurately split the width among all clips.
 #       Odd-resolution clips will also need to be taken into account.
-
-
-# Aliases:
-comp = compare
-scomp = stack_compare
-diff = tvbd_diff

--- a/lvsfunc/denoise.py
+++ b/lvsfunc/denoise.py
@@ -36,6 +36,8 @@ def quick_denoise(clip: vs.VideoNode,
 
     Special thanks to kageru for helping me out with some ideas and pointers.
 
+    Alias for this function is `lvsfunc.qden`.
+
     Dependencies: havsfunc (optional: SMDegrain mode), mvsfunc
 
     Deciphering havsfunc's dependencies is left as an excercise for the user.
@@ -152,7 +154,3 @@ def detail_mask(clip: vs.VideoNode, pre_denoise: Optional[float] = None,
     mask = core.std.Expr([mask_a, mask_b], 'x y max')
     mask = util.pick_removegrain(mask)(mask, 22)
     return util.pick_removegrain(mask)(mask, 11)
-
-
-# Alias:
-qden = quick_denoise

--- a/lvsfunc/misc.py
+++ b/lvsfunc/misc.py
@@ -27,6 +27,8 @@ def source(file: str, ref: Optional[vs.VideoNode] = None,
     It also automatically determines if an image has been imported.
     You can set its fps using 'fpsnum' and 'fpsden', or using a reference clip with 'ref'.
 
+    Alias for this function is `lvsfunc.src`.
+
     Dependencies:
 
         * d2vsource (optional: d2v sources)
@@ -97,6 +99,8 @@ def replace_ranges(clip_a: vs.VideoNode,
 
     Written by louis.
 
+    Alias for this function is `lvsfunc.rfs`.
+
     :param clip_a:     Original clip
     :param clip_b:     Replacement clip
     :param ranges:     Ranges to replace clip_a (original clip) with clip_b (replacement clip).
@@ -135,6 +139,8 @@ def edgefixer(clip: vs.VideoNode,
     and adds what are in my opinion "more sane" ways of handling the parameters and given values.
 
     ...If possible, you should be using bbmod instead, though.
+
+    Alias for this function is `lvsfunc.ef`.
 
     Dependencies: vs-continuityfixer
 
@@ -377,9 +383,3 @@ def chroma_injector(func: Callable[..., vs.VideoNode]) -> Callable[..., vs.Video
 #       It should optimally be able to accept anything and accurately reconstruct it,
 #       so long as the user gives it the right clips. Otherwise, it should assume
 #       that the chroma was scaled down using Nearest Neighbor or something alike.
-
-
-# Aliases:
-src = source
-rfs = replace_ranges
-ef = edgefixer


### PR DESCRIPTION
This should prevent Sphinx from auto-documenting the same function twice. We can't reference the alias as 
```
:py:func:`lvsfunc.alias`
```
as the aliases declared in __init__.py aren't documented.