### PR TITLE
tvbd_diff: Add `write_log` option

### DIFF
--- a/lvsfunc/comparison.py
+++ b/lvsfunc/comparison.py
@@ -14,6 +14,7 @@ import vapoursynth as vs
 import vsutil
 
 from .util import get_prop
+from .misc import get_ranges
 
 core = vs.core
 
@@ -542,21 +543,10 @@ def tvbd_diff(tv: vs.VideoNode, bd: vs.VideoNode,
         raise ValueError("tvbd_diff: no differences found")
 
     if write_log:
-        from itertools import groupby, count
-
-        def intervals(frames: list) -> list:
-            out = []
-            counter = count()
-
-            for key, group in groupby(frames, key=lambda x: x - next(counter)):
-                block = tuple(group)
-                out.append((block[0], block[-1]))
-            return out
-
         with open('./diff.log', 'a') as log:
             if ep_name:
                 log.write(f"{ep_name}: ")
-            log.write(f"{str(intervals(frames))} \n\n")
+            log.write(f"{str(get_ranges(frames))} \n\n")
 
     if return_array:
         tv, bd = tv.text.FrameNum(9), bd.text.FrameNum(9)

--- a/lvsfunc/misc.py
+++ b/lvsfunc/misc.py
@@ -151,7 +151,11 @@ def get_ranges(frames: List[int]) -> List[Union[int, Tuple[int, int]]]:
 
     for _, group in groupby(frames, key=lambda x: x - next(counter)):
         block = tuple(group)
-        ranges.append((block[0], block[-1]))
+        
+        if (start := block[0]) == (end := block[-1]):
+            ranges.append(start)
+        else:
+            ranges.append((start, end))
 
     return ranges
 

--- a/lvsfunc/misc.py
+++ b/lvsfunc/misc.py
@@ -5,6 +5,7 @@ import colorsys
 import os
 import random
 from functools import partial, wraps
+from itertools import groupby, count
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 
 import vapoursynth as vs
@@ -133,6 +134,26 @@ def replace_ranges(clip_a: vs.VideoNode,
             tmp = tmp + out[end + 1:]
         out = tmp
     return out
+
+
+def get_ranges(frames: List[int]) -> List[Union[int, Tuple[int, int]]]:
+    """
+    Identify groups of continuous frames intervals in a list
+
+    :param frames:     List of frames
+
+    :return:           Ranges of frames.
+                       Integer values in the list indicate single frames,
+                       Tuple values indicate inclusive ranges.
+    """
+    ranges = []
+    counter = count()
+
+    for _, group in groupby(frames, key=lambda x: x - next(counter)):
+        block = tuple(group)
+        ranges.append((block[0], block[-1]))
+
+    return ranges
 
 
 def edgefixer(clip: vs.VideoNode,


### PR DESCRIPTION
For example:
```python
frames = [
    3093, 3094, 3095, 3096, 3097, 3098, 3099, 3100, 3101, 3102, 3103, 3104, 3105, 3106, 3107, 3108, 3109, 3110, 3111,
    3112, 3113, 3114, 3115, 3116, 3117, 3118, 3119, 3120, 3121, 3122, 3123, 3124, 3125, 3126, 3127, 3128, 3129, 3130,
    3131, 3132, 3133, 3134, 3135, 3136, 3137, 3138, 3139, 3140, 3141, 3142, 3143, 3144, 3145, 3146, 3147, 3148, 3149,
    3150, 3151, 3152, 3153, 3154, 3155, 3156, 3157, 3158, 3159, 3160, 3161, 3162, 3163, 3164, 3165, 3166, 3167, 3168,
    3169, 3170, 3171, 3172, 3173, 3174, 3175, 34645, 34646, 34647, 34648, 34649, 34650, 34651, 34652, 34653, 34654,
    34655, 34656, 34657, 34658, 34659, 34660, 34661, 34662, 34663, 34664, 34665, 34666, 34667, 34668, 34669, 34670,
    34671, 34672, 34673, 34674, 34675, 34676, 34677, 34678, 34679, 34680, 34681, 34682, 34683, 34684, 34685, 34686,
    34687, 34688, 34689, 34690, 34691, 34692
]

write_log = True
#ep_name = 'e1'
ep_name = 'e2'

if write_log:
    from itertools import groupby, count

    def intervals(frames: list) -> list:
        out = []
        counter = count()

        for key, group in groupby(frames, key=lambda x: x - next(counter)):
            block = tuple(group)
            out.append((block[0], block[-1]))
        return out

    with open('./diff.log', 'a') as log:
        if ep_name:
            log.write(f"{ep_name}: ")
        log.write(f"{str(intervals(frames))} \n\n")
```
will create `./diff.log` that contains:
```
e1: [(3093, 3175), (34645, 34692)] 

e2: [(3093, 3175), (34645, 34692)] 

```