### PR TITLE
mask: Remove internally scaling in detail_mask

### DIFF
--- a/lvsfunc/mask.py
+++ b/lvsfunc/mask.py
@@ -46,7 +46,7 @@ def adaptive_mask(clip: vs.VideoNode, luma_scaling: float = 8.0) -> vs.VideoNode
 @functoolz.curry
 def detail_mask(clip: vs.VideoNode, sigma: Optional[float] = None,
                 rad: int = 3, radc: int = 2,
-                brz_a: float = 0.025, brz_b: float = 0.045) -> vs.VideoNode:
+                brz_a: float = None, brz_b: float = None) -> vs.VideoNode:
     """
     A wrapper for creating a detail mask to be used during denoising and/or debanding.
     The detail mask is created using debandshit's range mask,
@@ -61,22 +61,18 @@ def detail_mask(clip: vs.VideoNode, sigma: Optional[float] = None,
     :param sigma:       Sigma for Bilateral for pre-blurring (Default: False)
     :param rad:         The luma equivalent of gradfun3's "mask" parameter
     :param radc:        The chroma equivalent of gradfun3's "mask" parameter
-    :param brz_a:       Binarizing for the detail mask (Default: 0.025)
-    :param brz_b:       Binarizing for the edge mask (Default: 0.045)
+    :param brz_a:       Binarizing for the detail mask
+    :param brz_b:       Binarizing for the edge mask
 
     :return:            Detail mask
     """
     if clip.format is None:
         raise ValueError("detail_mask: 'Variable-format clips not supported'")
 
-    brz_a = scale_thresh(brz_a, clip)
-    brz_b = scale_thresh(brz_b, clip)
-
     blur = (util.quick_resample(clip, partial(core.bilateral.Gaussian, sigma=sigma))
             if sigma else clip)
 
     mask_a = range_mask(get_y(blur), rad=rad, radc=radc)
-    mask_a = depth(mask_a, clip.format.bits_per_sample, range=CRange.FULL, range_in=CRange.FULL)
     mask_a = core.std.Binarize(mask_a, brz_a)
 
     mask_b = core.std.Prewitt(get_y(blur))


### PR DESCRIPTION
Thus, the user can use any binarizing values, according to their clip depth.