### PR TITLE
mask: Fix range_mask function

### DIFF
--- a/lvsfunc/mask.py
+++ b/lvsfunc/mask.py
@@ -179,6 +179,9 @@ def range_mask(clip: vs.VideoNode, rad: int = 2, radc: Optional[int] = None) -> 
     if radc == 0:
         clip = get_y(clip)
 
+    if clip.format is None:
+        raise ValueError("range_mask: 'Variable-format clips not supported'")
+
     if clip.format.color_family == vs.GRAY:
         ma = _minmax(clip, rad, True)
         mi = _minmax(clip, rad, False)

--- a/lvsfunc/mask.py
+++ b/lvsfunc/mask.py
@@ -7,7 +7,7 @@ from functools import partial
 from typing import Callable, List, Optional, Tuple, Union
 
 import vapoursynth as vs
-from vsutil import depth, get_depth, get_y, iterate
+from vsutil import depth, get_depth, get_y, iterate, join, split
 from vsutil import Range as CRange
 
 from . import util
@@ -171,13 +171,27 @@ def range_mask(clip: vs.VideoNode, rad: int = 2, radc: Optional[int] = None) -> 
 
     :return:        Range mask
     """
-    radc = rad if radc is None else radc
+    if not rad:
+        rad = 0
+    if not radc:
+        radc = 0
+
     if radc == 0:
         clip = get_y(clip)
-    ma = _minmax(clip, rad, radc, maximum=True)
-    mi = _minmax(clip, rad, radc, maximum=False)
 
-    return core.std.Expr([ma, mi], expr='x y -')
+    if clip.format.color_family == vs.GRAY:
+        ma = _minmax(clip, rad, True)
+        mi = _minmax(clip, rad, False)
+        mask = core.std.Expr([ma, mi], 'x y -')
+    else:
+        planes = split(clip)
+        for i, rad_ in enumerate([rad, radc, radc]):
+            ma = _minmax(planes[i], rad_, True)
+            mi = _minmax(planes[i], rad_, False)
+            planes[i] = core.std.Expr([ma, mi], 'x y -')
+        mask = join(planes)
+
+    return mask
 
 
 # Helper functions
@@ -186,23 +200,12 @@ def _scale(value: int, peak: int) -> int:
     return math.floor(x + 0.5) if x > 0 else math.ceil(x - 0.5)
 
 
-def _minmax(clip: vs.VideoNode, sy: int = 2, sc: int = 2, maximum: bool = False) -> vs.VideoNode:
-    yp = sy >= sc
-    yiter = 1 if yp else 0
-    cp = sc >= sy
-    citer = 1 if cp else 0
-    planes = [0] if yp and not cp else [1, 2] if cp and not yp else [0, 1, 2]
-
-    if max(sy, sc) % 3 != 1:
-        coor = [0, 1, 0, 1, 1, 0, 1, 0]
-    else:
-        coor = [1] * 8
-
-    if sy > 0 or sc > 0:
-        func = clip.std.Maximum if maximum else clip.std.Minimum
-        return _minmax(func(planes=planes, coordinates=coor), sy=sy-yiter, sc=sc-citer)
-    else:
-        return clip
+def _minmax(clip: vs.VideoNode, iterations: int, maximum: bool) -> vs.VideoNode:
+    func = core.std.Maximum if maximum else core.std.Minimum
+    for i in range(1, iterations + 1):
+        coord = [0, 1, 0, 1, 1, 0, 1, 0] if (i % 3) != 1 else [1] * 8
+        clip = func(clip, coordinates=coord)
+    return clip
 
 
 class BoundingBox():


### PR DESCRIPTION
This PR should fix the wrong masking output (See #54 and #55). `debandshit.rangemask` is also bugged when you're trying to pass `radc=0` when input is GRAY.
The main difference is it processes now the planes independently.