### PR TITLE
Merge `wipe_row` branch

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,8 +113,6 @@ Functions
    lvsfunc.misc.get_matrix
    lvsfunc.misc.limit_dark
    lvsfunc.misc.load_bookmarks
-   lvsfunc.misc.replace_ranges
-   lvsfunc.misc.scale_thresh
    lvsfunc.misc.shift_tint
    lvsfunc.misc.source
    lvsfunc.misc.wipe_row
@@ -127,6 +125,8 @@ Functions
    lvsfunc.util.pick_removegrain
    lvsfunc.util.pick_repair
    lvsfunc.util.quick_resample
+   lvsfunc.util.replace_ranges
+   lvsfunc.util.scale_thresh
 
 lvsfunc.aa
 ---------------
@@ -303,8 +303,6 @@ lvsfunc.misc
    lvsfunc.misc.get_matrix
    lvsfunc.misc.limit_dark
    lvsfunc.misc.load_bookmarks
-   lvsfunc.misc.replace_ranges
-   lvsfunc.misc.scale_thresh
    lvsfunc.misc.shift_tint
    lvsfunc.misc.source
    lvsfunc.misc.wipe_row
@@ -383,6 +381,8 @@ lvsfunc.util
    lvsfunc.util.pick_removegrain
    lvsfunc.util.pick_repair
    lvsfunc.util.quick_resample
+   lvsfunc.util.replace_ranges
+   lvsfunc.util.scale_thresh
 
 .. automodule:: lvsfunc.util
    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -122,6 +122,7 @@ Functions
    lvsfunc.scale.descale_detail_mask
    lvsfunc.scale.reupscale
    lvsfunc.scale.test_descale
+   lvsfunc.util.normalize_ranges
    lvsfunc.util.pick_removegrain
    lvsfunc.util.pick_repair
    lvsfunc.util.quick_resample
@@ -378,6 +379,8 @@ lvsfunc.util
 
 .. autosummary::
 
+   lvsfunc.util.get_prop
+   lvsfunc.util.normalize_ranges
    lvsfunc.util.pick_removegrain
    lvsfunc.util.pick_repair
    lvsfunc.util.quick_resample

--- a/lvsfunc/__init__.py
+++ b/lvsfunc/__init__.py
@@ -8,13 +8,13 @@
 # flake8: noqa
 
 from . import (aa, comparison, dehardsub, deinterlace, denoise, kernels, mask,
-               misc, recon, scale, types)
+               misc, recon, scale, types, util)
 
 # Aliases:
 comp = comparison.compare
 diff = comparison.diff
 ef = misc.edgefixer
-rfs = misc.replace_ranges
+rfs = util.replace_ranges
 scomp = comparison.stack_compare
 sraa = aa.upscaled_sraa
 src = misc.source

--- a/lvsfunc/aa.py
+++ b/lvsfunc/aa.py
@@ -7,7 +7,7 @@ import vapoursynth as vs
 from vsutil import get_w, get_y
 
 from . import kernels, util
-from .misc import scale_thresh
+from .util import scale_thresh
 
 core = vs.core
 

--- a/lvsfunc/dehardsub.py
+++ b/lvsfunc/dehardsub.py
@@ -9,8 +9,8 @@ from abc import ABC
 from typing import Any, List, Optional, Tuple, Union
 
 from .mask import DeferredMask
-from .misc import replace_ranges, scale_thresh
 from .types import Range
+from .util import replace_ranges, scale_thresh
 
 core = vs.core
 

--- a/lvsfunc/mask.py
+++ b/lvsfunc/mask.py
@@ -10,7 +10,7 @@ from vsutil import depth, get_y, iterate, join, split
 from vsutil import Range as CRange
 
 from . import util
-from .misc import replace_ranges, scale_thresh
+from .util import replace_ranges, scale_thresh
 from .types import Position, Range, Size
 
 core = vs.core

--- a/lvsfunc/types.py
+++ b/lvsfunc/types.py
@@ -1,6 +1,6 @@
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
-Range = Union[int, Tuple[int, int]]
+Range = Union[Optional[int], Tuple[Optional[int], Optional[int]]]
 
 
 class Coordinate():

--- a/lvsfunc/util.py
+++ b/lvsfunc/util.py
@@ -1,10 +1,12 @@
 """
     Helper functions for the main functions in the script.
 """
-from typing import Any, Callable, Sequence, Type, TypeVar, Union, cast
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
 
 import vapoursynth as vs
 from vsutil import depth
+
+from .types import Range
 
 core = vs.core
 
@@ -97,3 +99,64 @@ def get_prop(frame: vs.VideoFrame, key: str, t: Type[T]) -> T:
         raise ValueError(f"get_prop: 'Key {key} did not contain expected type: Expected {t} got {real_type}'")
 
     return cast(T, prop)
+
+
+def replace_ranges(clip_a: vs.VideoNode,
+                   clip_b: vs.VideoNode,
+                   ranges: Union[Range, List[Range]]) -> vs.VideoNode:
+    """
+    A replacement for ReplaceFramesSimple that uses ints and tuples rather than a string.
+    Frame ranges are inclusive.
+
+    Written by louis.
+
+    Alias for this function is `lvsfunc.rfs`.
+
+    :param clip_a:     Original clip
+    :param clip_b:     Replacement clip
+    :param ranges:     Ranges to replace clip_a (original clip) with clip_b (replacement clip).
+                       Integer values in the list indicate single frames,
+                       Tuple values indicate inclusive ranges.
+
+    :return:           Clip with ranges from clip_a replaced with clip_b
+    """
+    if not isinstance(ranges, list):
+        ranges = [ranges]
+
+    out = clip_a
+
+    for r in ranges:
+        if type(r) is tuple:
+            start, end = cast(Tuple[int, int], r)
+        else:
+            start = cast(int, r)
+            end = cast(int, r)
+        tmp = clip_b[start:end + 1]
+        if start != 0:
+            tmp = out[: start] + tmp
+        if end < out.num_frames - 1:
+            tmp = tmp + out[end + 1:]
+        out = tmp
+    return out
+
+
+def scale_thresh(thresh: float, clip: vs.VideoNode, assume: Optional[int] = None) -> float:
+    """
+    Scale binarization thresholds from float to int.
+
+    :param thresh: Threshold [0, 1]. If greater than 1, assumed to be in native clip range
+    :param clip:   Clip to scale to
+    :param assume: Assume input is this depth when given input >1. If ``None``\\, assume ``clip``\\'s format.
+                   (Default: None)
+
+    :return:       Threshold scaled to [0, 2^clip.depth - 1] (if vs.INTEGER)
+    """
+    if clip.format is None:
+        raise ValueError("scale_thresh: 'Variable-format clips not supported.'")
+    if thresh < 0:
+        raise ValueError("scale_thresh: 'Thresholds must be positive.'")
+    if thresh > 1:
+        return thresh if not assume \
+            else round(thresh/((1 << assume) - 1) * ((1 << clip.format.bits_per_sample) - 1))
+    return thresh if clip.format.sample_type == vs.FLOAT or thresh > 1 \
+        else round(thresh * ((1 << clip.format.bits_per_sample) - 1))


### PR DESCRIPTION
**Changelog**

Function updates:
* wipe_row
    - Now uses `mask.BoundingBox` for masking rather than `kagefunc.squaremask`
    - `secondary` has been renamed to `ref`
    - Removed second squaremask, just run the function twice

* replace_ranges
    - Moved to `util` (should still work if called from `misc` for the foreseeable future)
    - Allow negative and nonetype inputs
        - See docstrings for more information on how they function

* scale_thresh
    - Moved to `util` (should still work if called from `misc` for the foreseeable future)


Misc:
* New normalized_ranges function
* mypy fixes, more minor code cleaning