### PR TITLE
diff: add return_ranges and exclude_range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.cfg
 *.pyc
 *.vpy
+tests/
 BACK-UP/
 build/
 dist/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,6 +104,7 @@ Functions
    lvsfunc.comparison.stack_vertical
    lvsfunc.comparison.tile
    lvsfunc.deblock.autodb_dpir
+   lvsfunc.deblock.prot_dpir
    lvsfunc.dehalo.bidehalo
    lvsfunc.dehalo.deemphasize
    lvsfunc.dehardsub.bounded_dehardsub
@@ -191,6 +192,7 @@ lvsfunc.deblock
 .. autosummary::
 
    lvsfunc.deblock.autodb_dpir
+   lvsfunc.deblock.prot_dpir
 
 .. automodule:: lvsfunc.deblock
    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ The following VapourSynth libraries are also required for full functionality:
 * `VapourSynth-BM3D <https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D>`_
 * `VapourSynth-descale <https://github.com/Irrational-Encoding-Wizardry/VapourSynth-descale>`_
 * `VapourSynth-EEDI3 <https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3>`_
+* `VapourSynth-fillborders <https://github.com/dubhater/vapoursynth-fillborders>`_
 * `VapourSynth-nnedi3 <https://github.com/dubhater/VapourSynth-nnedi3>`_
 * `VapourSynth-NNEDI3CL <https://github.com/HomeOfVapourSynthEvolution/VapourSynth-NNEDI3CL3>`_
 * `VapourSynth-ReadMpls <https://github.com/HomeOfVapourSynthEvolution/VapourSynth-ReadMpls>`_
@@ -138,6 +139,7 @@ Functions
    lvsfunc.scale.reupscale
    lvsfunc.scale.test_descale
    lvsfunc.util.normalize_ranges
+   lvsfunc.util.padder
    lvsfunc.util.pick_removegrain
    lvsfunc.util.pick_repair
    lvsfunc.util.quick_resample
@@ -408,6 +410,7 @@ lvsfunc.util
 
    lvsfunc.util.get_prop
    lvsfunc.util.normalize_ranges
+   lvsfunc.util.padder
    lvsfunc.util.pick_removegrain
    lvsfunc.util.pick_repair
    lvsfunc.util.quick_resample

--- a/lvsfunc/comparison.py
+++ b/lvsfunc/comparison.py
@@ -487,7 +487,7 @@ def diff(*clips: vs.VideoNode,
          return_array: bool = False,
          return_frames: bool = False,
          return_ranges: bool = False,
-         exclude_ranges: List[Tuple(int,int)] = None,
+         exclude_ranges: List[Tuple[int, int]] = None,
          diff_func: Callable[[vs.VideoNode, vs.VideoNode], vs.VideoNode] = lambda a, b: core.std.MakeDiff(a, b),
          **namedclips: vs.VideoNode) -> Union[vs.VideoNode, Tuple[vs.VideoNode, List[int]]]:
     """
@@ -518,7 +518,7 @@ def diff(*clips: vs.VideoNode,
                           (Default: ``False``)
     :param return_frames: Adds `frames list` to the return. (Default: ``False``)
     :param return_ranges: Adds `frames ranges list` to the return. Supercedes `return_frames`. (Default: ``False``)
-    :param exclude_ranges: Excludes a list of frame ranges from difference checking. (Default: ``False``)
+    :param exclude_ranges: Excludes a list of frame ranges from difference checking output (but not processing). (Default: ``False``)
     :param diff_func:     Function for calculating diff in PlaneStatsMin/Max mode.
                           (Default: core.std.MakeDiff)
 
@@ -584,10 +584,9 @@ def diff(*clips: vs.VideoNode,
 
     if exclude_ranges is not None:
         for e in exclude_ranges:
-            start, end = e[0],e[1]
-            for f in frames:
-                if f in range(start,end+1):
-                    frames.remove(f) 
+            start, end = e[0], e[1]+1
+            r = range(start,end)
+            frames = [f for f in list(frames) if f not in r]
 
     if clips:
         name_a, name_b = "Clip A", "Clip B"

--- a/lvsfunc/comparison.py
+++ b/lvsfunc/comparison.py
@@ -487,7 +487,7 @@ def diff(*clips: vs.VideoNode,
          return_array: bool = False,
          return_frames: bool = False,
          return_ranges: bool = False,
-         exclude_ranges: List[Tuple[int, int]] = None,
+         exclude_ranges: Optional[List[Tuple[int, int]]] = None,
          diff_func: Callable[[vs.VideoNode, vs.VideoNode], vs.VideoNode] = lambda a, b: core.std.MakeDiff(a, b),
          **namedclips: vs.VideoNode) -> Union[vs.VideoNode, Tuple[vs.VideoNode, List[int]]]:
     """
@@ -518,7 +518,7 @@ def diff(*clips: vs.VideoNode,
                           (Default: ``False``)
     :param return_frames: Adds `frames list` to the return. (Default: ``False``)
     :param return_ranges: Adds `frames ranges list` to the return. Supercedes `return_frames`. (Default: ``False``)
-    :param exclude_ranges: Excludes a list of frame ranges from difference checking output (but not processing). (Default: ``False``)
+    :param exclude_ranges: Excludes a list of frame ranges from difference checking. (Default: ``False``)
     :param diff_func:     Function for calculating diff in PlaneStatsMin/Max mode.
                           (Default: core.std.MakeDiff)
 
@@ -584,9 +584,10 @@ def diff(*clips: vs.VideoNode,
 
     if exclude_ranges is not None:
         for e in exclude_ranges:
-            start, end = e[0], e[1]+1
-            r = range(start,end)
-            frames = [f for f in list(frames) if f not in r]
+            start, end = e[0], e[1]
+            for f in frames:
+                if f in range(start, end+1):
+                    frames.remove(f)
 
     if clips:
         name_a, name_b = "Clip A", "Clip B"

--- a/lvsfunc/types.py
+++ b/lvsfunc/types.py
@@ -6,7 +6,7 @@ Range = Union[Optional[int], Tuple[Optional[int], Optional[int]]]
 
 class Coordinate():
     """
-    A positive set of (x, y) coodinates.
+    A positive set of (x, y) coordinates.
     """
     x: int
     y: int

--- a/stubs/vapoursynth/vapoursynth.pyi
+++ b/stubs/vapoursynth/vapoursynth.pyi
@@ -710,6 +710,24 @@ class _Plugin_f3kdb_Bound(Plugin):
 # end implementation
 
 
+# implementation: fb
+class _Plugin_fb_Unbound(Plugin):
+    """
+    This class implements the module definitions for the corresponding VapourSynth plugin.
+    This class cannot be imported.
+    """
+    def FillBorders(self, clip: "VideoNode", left: typing.Optional[int] = None, right: typing.Optional[int] = None, top: typing.Optional[int] = None, bottom: typing.Optional[int] = None, mode: typing.Union[str, bytes, bytearray, None] = None, interlaced: typing.Optional[int] = None) -> "VideoNode": ...
+
+
+class _Plugin_fb_Bound(Plugin):
+    """
+    This class implements the module definitions for the corresponding VapourSynth plugin.
+    This class cannot be imported.
+    """
+    def FillBorders(self, left: typing.Optional[int] = None, right: typing.Optional[int] = None, top: typing.Optional[int] = None, bottom: typing.Optional[int] = None, mode: typing.Union[str, bytes, bytearray, None] = None, interlaced: typing.Optional[int] = None) -> "VideoNode": ...
+# end implementation
+
+
 # implementation: ffms2
 class _Plugin_ffms2_Unbound(Plugin):
     """
@@ -1846,6 +1864,13 @@ class VideoNode:
         flash3kyuu_deband
         """
 # end instance
+# instance_bound: fb
+    @property
+    def fb(self) -> _Plugin_fb_Bound:
+        """
+        FillBorders plugin for VapourSynth
+        """
+# end instance
 # instance_bound: ffms2
     @property
     def ffms2(self) -> _Plugin_ffms2_Bound:
@@ -2293,6 +2318,13 @@ class Core:
     def f3kdb(self) -> _Plugin_f3kdb_Unbound:
         """
         flash3kyuu_deband
+        """
+# end instance
+# instance_unbound: fb
+    @property
+    def fb(self) -> _Plugin_fb_Unbound:
+        """
+        FillBorders plugin for VapourSynth
         """
 # end instance
 # instance_unbound: ffms2


### PR DESCRIPTION
Add ability to return a list of ranges of frame sequences and to exclude frame ranges from difference checking.

satisfies some requirements of https://github.com/Irrational-Encoding-Wizardry/lvsfunc/issues/65