### PR TITLE
Add audio_async_render

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,7 @@ Functions
    lvsfunc.misc.wipe_row
    lvsfunc.recon.chroma_reconstruct
    lvsfunc.render.clip_async_render
+   lvsfunc.render.audio_async_render
    lvsfunc.render.find_scene_changes
    lvsfunc.render.get_render_process
    lvsfunc.scale.descale
@@ -368,6 +369,7 @@ lvsfunc.render
 .. autosummary::
 
    lvsfunc.render.clip_async_render
+   lvsfunc.render.audio_async_render
    lvsfunc.render.find_scene_changes
    lvsfunc.render.get_render_process
 

--- a/lvsfunc/render.py
+++ b/lvsfunc/render.py
@@ -1,45 +1,68 @@
 """
-    Clip rendering helpers.
+Node rendering helpers.
 """
+import struct
+from abc import ABC
+from concurrent.futures import Future
+from enum import Enum, IntEnum
+from functools import partial
+from threading import Condition
+from typing import (BinaryIO, Callable, Dict, Generic, List, Optional, TextIO,
+                    TypeVar, Union)
+
+import numpy as np
 import vapoursynth as vs
 
-from enum import Enum
-from threading import Condition
-from typing import BinaryIO, Callable, Dict, List, Optional, TextIO, Union
-from concurrent.futures import Future
-from functools import partial
-
-from .progress import Progress, BarColumn, FPSColumn, TextColumn, TimeRemainingColumn
+from .progress import (BarColumn, FPSColumn, Progress, TextColumn,
+                       TimeRemainingColumn)
 from .util import get_prop
 
 core = vs.core
 
 RenderCallback = Callable[[int, vs.VideoFrame], None]
+Node = TypeVar('Node', bound=Union[vs.VideoNode, vs.AudioNode])
+Frame = TypeVar('Frame', bound=Union[vs.VideoFrame, vs.AudioFrame])
 
 
-class RenderContext:
+class RenderContext(Generic[Node, Frame], ABC):
     """
     Contains info on the current render operation.
     """
-    clip: vs.VideoNode
+    node: Node
     queued: int
-    frames: Dict[int, vs.VideoFrame]
+    frames: Dict[int, Frame]
     frames_rendered: int
-    timecodes: List[float]
     condition: Condition
 
-    def __init__(self, clip: vs.VideoNode, queued: int) -> None:
-        self.clip = clip
+    def __init__(self, node: Node, queued: int) -> None:
+        self.node = node
         self.queued = queued
         self.frames = {}
         self.frames_rendered = 0
-        self.timecodes = [0.0]
         self.condition = Condition()
 
 
-def finish_frame(outfile: Optional[BinaryIO], timecodes: Optional[TextIO], ctx: RenderContext) -> None:
+class RenderContextVideo(RenderContext[vs.VideoNode, vs.VideoFrame]):
     """
-    Output a frame.
+    Contains info on the current render operation for video.
+    """
+    timecodes: List[float]
+
+    def __init__(self, node: vs.VideoNode, queued: int) -> None:
+        self.timecodes = [0.0]
+        super().__init__(node, queued)
+
+
+class RenderContextAudio(RenderContext[vs.AudioNode, vs.AudioFrame]):
+    """
+    Contains info on the current render operation for audio.
+    """
+    ...
+
+
+def finish_frame_video(outfile: Optional[BinaryIO], timecodes: Optional[TextIO], ctx: RenderContextVideo) -> None:
+    """
+    Output a video frame.
 
     :param outfile:   Output IO handle for Y4MPEG
     :param timecodes: Output IO handle for timecodesv2
@@ -59,6 +82,31 @@ def finish_frame(outfile: Optional[BinaryIO], timecodes: Optional[TextIO], ctx: 
             outfile.write(bytes(p))  # type: ignore
         else:
             outfile.write(p)  # type: ignore
+
+
+def finish_frame_audio(outfile: BinaryIO, ctx: RenderContextAudio, _24bit: bool = False) -> None:
+    """
+    Output an audio frame.
+
+    :param outfile: Output IO handle for WAVE or WAVE64
+    :param ctx:     Rendering context
+    :param _24bit:  If bitdepth is 24.
+    """
+    f = ctx.frames[ctx.frames_rendered]
+
+    # For some reason f[i] is faster than list(f) or just passing f to stack
+    data = np.stack([f[i] for i in range(f.num_channels)], axis=1)
+
+    if _24bit:
+        if data.ndim == 1:
+            # Convert to a 2D array with a single column
+            data.shape += (1, )
+        # Data values are stored in 32 bits so we must convert them to 24 bits
+        # Then by shifting first 0 bits, then 8, then 16, the resulting output is 24 bit little-endian.
+        data = ((data // 2 ** 8).reshape(data.shape + (1, )) >> np.array([0, 8, 16]))
+        outfile.write(data.ravel().astype(np.uint8).tobytes())
+    else:
+        outfile.write(data.ravel().view(np.int8).tobytes())
 
 
 def clip_async_render(clip: vs.VideoNode,
@@ -98,7 +146,7 @@ def clip_async_render(clip: vs.VideoNode,
 
         cbl.append(_progress_cb)
 
-    ctx = RenderContext(clip, core.num_threads)
+    ctx = RenderContextVideo(clip, core.num_threads)
 
     bad_timecodes: bool = False
 
@@ -124,7 +172,7 @@ def clip_async_render(clip: vs.VideoNode,
                 ctx.timecodes.append(ctx.timecodes[-1]
                                      + get_prop(frame, "_DurationNum", int)
                                      / get_prop(frame, "_DurationDen", int))
-            finish_frame(outfile, timecodes, ctx)
+            finish_frame_video(outfile, timecodes, ctx)
             [cb(ctx.frames_rendered, ctx.frames[ctx.frames_rendered]) for cb in cbl]
             del ctx.frames[ctx.frames_rendered]  # tfw no infinite memory
             ctx.frames_rendered += 1
@@ -189,6 +237,194 @@ def clip_async_render(clip: vs.VideoNode,
             p.stop()
 
     return ctx.timecodes  # might as well
+
+
+class WaveFormat(IntEnum):
+    """
+    WAVE form wFormatTag IDs
+    Complete list is in mmreg.h in Windows 10 SDK.
+    """
+    PCM = 0x0001
+    IEEE_FLOAT = 0x0003
+    EXTENSIBLE = 0xFFFE
+
+
+class WaveHeader(IntEnum):
+    """
+    Wave headers
+    """
+    WAVE = 0
+    WAVE64 = 1
+    AUTO = 2
+
+
+WAVE_RIFF_TAG = b'RIFF'
+WAVE_WAVE_TAG = b'WAVE'
+WAVE_FMT_TAG = b'fmt '
+WAVE_DATA_TAG = b'data'
+
+WAVE64_RIFF_UUID = (0x72, 0x69, 0x66, 0x66, 0x2E, 0x91, 0xCF, 0x11, 0xA5, 0xD6, 0x28, 0xDB, 0x04, 0xC1, 0x00, 0x00)
+WAVE64_WAVE_UUID = (0x77, 0x61, 0x76, 0x65, 0xF3, 0xAC, 0xD3, 0x11, 0x8C, 0xD1, 0x00, 0xC0, 0x4F, 0x8E, 0xDB, 0x8A)
+WAVE64_FMT_UUID = (0x66, 0x6D, 0x74, 0x20, 0xF3, 0xAC, 0xD3, 0x11, 0x8C, 0xD1, 0x00, 0xC0, 0x4F, 0x8E, 0xDB, 0x8A)
+WAVE64_DATA_UUID = (0x64, 0x61, 0x74, 0x61, 0xF3, 0xAC, 0xD3, 0x11, 0x8C, 0xD1, 0x00, 0xC0, 0x4F, 0x8E, 0xDB, 0x8A)
+WAVE_FMT_EXTENSIBLE_SUBFORMAT = (
+    (WaveFormat.PCM, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71),
+    (WaveFormat.IEEE_FLOAT, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71)
+)
+
+
+def audio_async_render(audio: vs.AudioNode,
+                       outfile: BinaryIO,
+                       header: WaveHeader = WaveHeader.AUTO,
+                       progress: Optional[str] = "Rendering audio...") -> None:
+    """
+    Render an audio by requesting frames asynchronously using audio.get_frame_async.
+
+    Implementation-like of VideoNode.output for an AudioNode that isn't in the Cython side yet.
+
+    :param audio:       Audio to render.
+    :param outfile:     Render output BinaryIO handle.
+    :param header:      Kind of Wave header.
+                        WaveHeader.AUTO adds a Wave64 header if the audio
+
+                        * Has more than 2 channels
+                        * Has a bitdepth > 16
+                        * Has more than 44100 samples
+
+    :param progress:    String to use for render progress display.
+                        If empty or ``None``, no progress display.
+    """
+    if progress:
+        p = get_render_progress()
+        task = p.add_task(progress, total=audio.num_frames)
+
+    ctx = RenderContextAudio(audio, core.num_threads)
+
+    def cb(f: Future[vs.AudioFrame], n: int) -> None:
+        ctx.frames[n] = f.result()
+        nn = ctx.queued
+
+        while ctx.frames_rendered in ctx.frames:
+            finish_frame_audio(outfile, ctx, audio.bits_per_sample == 24)
+
+            if progress:
+                p.update(task, advance=1)
+
+            del ctx.frames[ctx.frames_rendered]  # tfw no infinite memory
+            ctx.frames_rendered += 1
+
+        # enqueue a new frame
+        if nn < audio.num_frames:
+            ctx.queued += 1
+            cbp = partial(cb, n=nn)
+            audio.get_frame_async(nn).add_done_callback(cbp)  # type: ignore
+
+        ctx.condition.acquire()
+        ctx.condition.notify()
+        ctx.condition.release()
+
+    bytes_per_output_sample = (audio.bits_per_sample + 7) // 8
+    block_align = audio.num_channels * bytes_per_output_sample
+    bytes_per_second = audio.sample_rate * block_align
+    data_size = audio.num_samples * block_align
+
+    if header == WaveHeader.AUTO:
+        conditions = (audio.num_channels > 2, audio.bits_per_sample > 16, audio.num_samples > 44100)
+        header_func, use_w64 = (_w64_header, 1) if any(conditions) else (_wav_header, 0)
+    else:
+        use_w64 = int(header)
+        header_func = (_wav_header, _w64_header)[header]
+
+    outfile.write(header_func(audio, bytes_per_second, block_align, data_size))
+
+    ctx.condition.acquire()
+
+    # seed threads
+    if progress:
+        p.start()
+    try:
+        for n in range(min(audio.num_frames, core.num_threads)):
+            cbp = partial(cb, n=n)  # lambda won't bind the int immediately
+            audio.get_frame_async(n).add_done_callback(cbp)  # type: ignore
+
+        while ctx.frames_rendered != audio.num_frames:
+            ctx.condition.wait()
+    finally:
+        # Determine file size and place the value at the correct position
+        # at the beginning of the file
+        size = outfile.tell()
+        if use_w64:
+            outfile.seek(16)
+            outfile.write(struct.pack('<Q', size))
+        else:
+            outfile.seek(4)
+            outfile.write(struct.pack('<I', size - 8))
+        if progress:
+            p.stop()
+
+
+def _wav_header(audio: vs.AudioNode, bps: int, block_align: int, data_size: int) -> bytes:
+    header = WAVE_RIFF_TAG
+    # Add 4 bytes for the length later
+    header += b'\x00\x00\x00\x00'
+    header += WAVE_WAVE_TAG
+
+    header += WAVE_FMT_TAG
+    format_tag = WaveFormat.IEEE_FLOAT if audio.sample_type == vs.FLOAT else WaveFormat.PCM
+
+    fmt_chunk_data = struct.pack(
+        '<HHIIHH', format_tag, audio.num_channels, audio.sample_rate,
+        bps, block_align, audio.bits_per_sample
+    )
+    header += struct.pack('<I', len(fmt_chunk_data))
+    header += fmt_chunk_data
+
+    if len(header) + data_size > 0xFFFFFFFE:
+        raise ValueError('Data exceeds wave file size limit')
+
+    header += WAVE_DATA_TAG
+    header += struct.pack('<I', data_size)
+    return header
+
+
+def _w64_header(audio: vs.AudioNode, bps: int, block_align: int, data_size: int) -> bytes:
+    # RIFF-GUID
+    header = bytes(WAVE64_RIFF_UUID)
+    # Add 8 bytes for the length later
+    header += b'\x00\x00\x00\x00\x00\x00\x00\x00'
+    # WAVE-GUID
+    header += bytes(WAVE64_WAVE_UUID)
+    # FMT-GUID
+    fmt_guid = bytes(WAVE64_FMT_UUID)
+    header += fmt_guid
+
+    # We only support WAVEFORMATEXTENSIBLE for WAVE64 header
+    format_tag = WaveFormat.EXTENSIBLE
+
+    # cb_size should be 22 for WAVEFORMATEXTENSIBLE with PCM
+    cb_size = 22
+    fmt_chunk_data = struct.pack(
+        '<HHIIHHHHI', format_tag, audio.num_channels, audio.sample_rate,
+        bps, block_align, audio.bits_per_sample, cb_size,
+        audio.bits_per_sample,  # valid bit per sample
+        audio.channel_layout
+    )
+    # Add the subformat GUID, first 2 bytes have format type, 1 being PCM
+    fmt_chunk_data += bytes(WAVE_FMT_EXTENSIBLE_SUBFORMAT[audio.sample_type])
+
+    # Add the FMT size
+    # Length of the FMT-GUID + length of FMT data and 8 for the bytes themself
+    header += struct.pack('<Q', len(fmt_guid) + 8 + len(fmt_chunk_data))
+    header += fmt_chunk_data
+
+    # # Finally write the header
+    # outfile.write(header)
+
+    # DATA-GUID
+    data_uuid = bytes(WAVE64_DATA_UUID)
+    header += data_uuid
+    header += struct.pack('<Q', data_size + len(data_uuid) + 8)
+    return header
 
 
 def get_render_progress() -> Progress:

--- a/lvsfunc/render.py
+++ b/lvsfunc/render.py
@@ -330,9 +330,9 @@ def audio_async_render(audio: vs.AudioNode,
 
     if header == WaveHeader.AUTO:
         conditions = (audio.num_channels > 2, audio.bits_per_sample > 16, audio.num_samples > 44100)
-        header_func, use_w64 = (_w64_header, 1) if any(conditions) else (_wav_header, 0)
+        header_func, use_w64 = (_w64_header, WaveHeader.WAVE64) if any(conditions) else (_wav_header, WaveHeader.WAVE)
     else:
-        use_w64 = int(header)
+        use_w64 = header
         header_func = (_wav_header, _w64_header)[header]
 
     outfile.write(header_func(audio, bytes_per_second, block_align, data_size))
@@ -416,9 +416,6 @@ def _w64_header(audio: vs.AudioNode, bps: int, block_align: int, data_size: int)
     # Length of the FMT-GUID + length of FMT data and 8 for the bytes themself
     header += struct.pack('<Q', len(fmt_guid) + 8 + len(fmt_chunk_data))
     header += fmt_chunk_data
-
-    # # Finally write the header
-    # outfile.write(header)
 
     # DATA-GUID
     data_uuid = bytes(WAVE64_DATA_UUID)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ MarkupSafe==1.1.1
 mccabe==0.6.1
 mypy==0.910
 mypy-extensions==0.4.3
+numpy>=1.21.2
 packaging==21.0
 pycodestyle==2.7.0
 pyflakes==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 VapourSynth>=51
+numpy>=1.21.2
 packaging>=21.0
 rich>=8.0.0
 toolz>=0.9.0.1


### PR DESCRIPTION
This PR adds `audio_async_render`. It works the same way as `clip_aync_render`, requesting frames asynchronously using `get_frame_async`.

I had to modify a part of the code to make it work like renaming RenderContext and finish_frame.
I tried to add a lot of comments to better understand the code since I had to document myself to write the function.

I think adding the URLs I used in the code wouldn't be best idea so here are them:

https://web.archive.org/web/20051028052230/http://media.vcs.de/Downloads/Sony_Wave64.pdf
https://github.com/vapoursynth/vapoursynth/blob/master/src/common/wave.cpp
https://github.com/xiph/flac/blob/27c615706cedd252a206dd77e3910dfa395dcc49/src/flac/encode.c
https://github.com/tpn/winsdk-10/blob/master/Include/10.0.14393.0/shared/mmreg.h#L2107
https://docs.microsoft.com/en-us/windows/win32/api/mmreg/ns-mmreg-waveformatextensible
https://github.com/scipy/scipy/pull/6852
https://gist.github.com/josephernest/3f22c5ed5dabf1815f16efa8fa53d476
https://stackoverflow.com/questions/31739143/when-to-use-wave-extensible-format


# Why in lvsfunc?
Well there is already clip_async_render and there is relatively duplicated code. I didn't change anything inside `clip_aync_render` but changes could be made now that audio is a thing in Vapoursynth.

# Why numpy?
A vapoursynth.RawFrame is a Sequence like of memoryviews. We need to stack them to perform computations. I don't know if a solution without numpy exists but it would probably be slower.
Numpy is used quite enough in python environment and some vapoursynth *funcs need it. Plus it's a pretty solid package highly maintained.


# Performance
I still need to do proper performance comparisons but it's ~40 % slower than vspipe. Makes sense since it's done in python and not in C.

24:28 minutes 24 bit wave file:
* `audio_async_render` Duration: 16.13 seconds
* `vspipe` Duration 11.20 seconds
