### PR TITLE
Fix doc typing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,4 +16,4 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install -r docs/requirements.txt
       - name: Running sphinx
-        run: python3 setup.py build_sphinx
+        run: python3 setup.py build_sphinx -W --keep-going

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
    configuration: docs/conf.py
+   fail_on_warning: true
 
 python:
    install:

--- a/docs/changelogs/changelogs.rst
+++ b/docs/changelogs/changelogs.rst
@@ -25,12 +25,12 @@ v0.4.2
 
 **New additions**
 * `get_matrix_curve`
-    - Returns a `TransferCharacteristics` based on a given `matrix`.
+    * Returns a `TransferCharacteristics` based on a given `matrix`.
 * `chickendream`
-    - A wrapper around the graining plugin, chickendream, a plug-in that implements a realistic film grain generator.
+    * A wrapper around the graining plugin, chickendream, a plug-in that implements a realistic film grain generator.
 * `check_variable_format`
 * `check_variable_resolution`
-    - Separated functionality from `check_variable` into their own functions. `check_variable` still checks both.
+    * Separated functionality from `check_variable` into their own functions. `check_variable` still checks both.
 * New custom exceptions. Please check [the documentation for a full list](https://lvsfunc.encode.moe/en/latest/submodules/exceptions.html).
 
 **Updates**

--- a/docs/changelogs/changelogs.rst
+++ b/docs/changelogs/changelogs.rst
@@ -15,6 +15,7 @@ v0.4.2
 **lvsfunc now requires Python 3.10 and VapourSynth 58!**
 
 **Changelog**
+
 * setup.py updates, should now show extra info on pypi
 * Docs overhaul
 * Lots of docstrings updated to include additional information and warnings
@@ -24,6 +25,7 @@ v0.4.2
 * `denoise` renamed to `noise`. Temporary alias still exists.
 
 **New additions**
+
 * `get_matrix_curve`
     * Returns a `TransferCharacteristics` based on a given `matrix`.
 * `chickendream`
@@ -34,6 +36,7 @@ v0.4.2
 * New custom exceptions. Please check [the documentation for a full list](https://lvsfunc.encode.moe/en/latest/submodules/exceptions.html).
 
 **Updates**
+
 * All masking functions now automatically limit their output (This means no weird masking shenanigans because of out-of-range values)
 * `get_matrix`: New option to return `types.Matrix` instead of an int. This will at some point become the default behaviour.
 * `tivtc_vfr`: Should now properly allow users to do an analysis pass without erroring (See: #90. Thanks @Setsugennoao and @RivenSkaye!)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,3 +75,5 @@ autodoc_mock_imports = ["vsutil", "vapoursynth"]
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+html_static_path = []

--- a/lvsfunc/deblock.py
+++ b/lvsfunc/deblock.py
@@ -136,7 +136,8 @@ def autodb_dpir(clip: vs.VideoNode, edgevalue: int = 24,
 def vsdpir(clip: vs.VideoNode, strength: VSDPIR_STRENGTH_TYPE = 25, mode: str = 'deblock',
            matrix: Matrix | int | None = None, tiles: int | Tuple[int] | None = None,
            cuda: bool | Literal['trt'] = True, i444: bool = False, kernel: Kernel | str = Catrom(),
-           zones: List[Tuple[Range, VSDPIR_STRENGTH_TYPE]] | None = None, **dpir_args: Any) -> vs.VideoNode:
+           zones: List[Tuple[Range | List[Range] | None, VSDPIR_STRENGTH_TYPE]] | None = None,
+           **dpir_args: Any) -> vs.VideoNode:
     """
     A simple vs-mlrt DPIR wrapper for convenience.
 
@@ -258,7 +259,10 @@ def vsdpir(clip: vs.VideoNode, strength: VSDPIR_STRENGTH_TYPE = 25, mode: str = 
                     strength_clip, zstr if isinstance(zstr, vs.VideoNode) else _get_strength_clip(zstr), ranges
                 )
             else:
-                no_dpir_zones.append(ranges)
+                if isinstance(ranges, List):
+                    no_dpir_zones.extend(ranges)
+                else:
+                    no_dpir_zones.append(ranges)
 
     run_dpir = DPIR(clip_rgb, strength_clip, **dpir_args)
 

--- a/lvsfunc/deblock.py
+++ b/lvsfunc/deblock.py
@@ -7,12 +7,10 @@ import vapoursynth as vs
 from vsutil import Dither, depth, get_depth
 
 from .kernels import Catrom, Kernel, Point, get_kernel
-from .types import Matrix, Range
+from .types import Matrix, Range, VSDPIR_STRENGTH_TYPE
 from .util import check_variable, get_prop, replace_ranges
 
 core = vs.core
-
-VSDPIR_STRENGTH_TYPE = SupportsFloat | vs.VideoNode | None
 
 __all__: List[str] = [
     'autodb_dpir', 'vsdpir'

--- a/lvsfunc/types.py
+++ b/lvsfunc/types.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from enum import IntEnum
 from typing import (Any, Callable, List, Literal, NamedTuple, NoReturn,
-                    Optional, Protocol, Sequence, Tuple, TypeVar, Union)
+                    Optional, Protocol, Sequence, SupportsFloat, Tuple,
+                    TypeVar, Union)
 
 import vapoursynth as vs
 
@@ -15,6 +16,7 @@ __all__: List[str] = [
 CreditMask = Callable[[vs.VideoNode, vs.VideoNode], vs.VideoNode]
 CustomScaler = Callable[[vs.VideoNode, int, int], vs.VideoNode]
 Range = Union[Optional[int], Tuple[Optional[int], Optional[int]]]
+VSDPIR_STRENGTH_TYPE = Optional[Union[SupportsFloat, vs.VideoNode]]
 
 
 VideoProp = Union[


### PR DESCRIPTION
The new VSDPIR_STRENGTH_TYPE type broke the doc building. This has been fixed.
rtd will now also throw an error if there's any warnings, which should hopefully prevent the docs from breaking without my noticing from now on.
vsdpir's zones typing has also been updated to properly reflect what can be passed.