### PR TITLE
Fine dehalo update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: release
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  release:
   workflow_run:
     workflows: ["lint", "docs"]
     types:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_run:
     workflows: ["lint", "docs"]
     types:

--- a/docs/submodules/mask.rst
+++ b/docs/submodules/mask.rst
@@ -12,6 +12,7 @@ All masks also come limited by default, so you don't need to worry about illegal
     lvsfunc.mask.DeferredMask
     lvsfunc.mask.detail_mask
     lvsfunc.mask.detail_mask_neo
+    lvsfunc.mask.fine_dehalo_mask
     lvsfunc.mask.halo_mask
     lvsfunc.mask.mt_xxpand_multi
     lvsfunc.mask.range_mask

--- a/lvsfunc/dehalo.py
+++ b/lvsfunc/dehalo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from functools import partial
 from typing import Any, Dict, List, Sequence
 
@@ -9,8 +10,8 @@ from vsutil import depth, fallback, get_depth, get_y
 from .kernels import BSpline, Catrom
 from .mask import fine_dehalo_mask
 from .noise import bm3d
-from .util import (check_variable, clamp_values, force_mod,
-                   pick_repair, scale_peak)
+from .util import (check_variable, clamp_values, force_mod, pick_repair,
+                   scale_peak)
 
 core = vs.core
 
@@ -178,6 +179,9 @@ def fine_dehalo(clip: vs.VideoNode, ref: vs.VideoNode | None = None,
                 show_mask: bool | int = False,
                 planes: int | Sequence[int] | None = None) -> vs.VideoNode:
     """
+    .. warning::
+        | This function has been deprecated! It will removed in a future commit.
+
     Slight rewrite of fine_dehalo.
 
     This is a slight rewrite of the standalone script that has been floating around
@@ -220,6 +224,9 @@ def fine_dehalo(clip: vs.VideoNode, ref: vs.VideoNode | None = None,
 
     :return:                Dehalo'd clip or halo mask clip
     """
+    warnings.warn("fine_dehalo: 'This function is deprecated in favor of `stgfunc.dehalo.fine_dehalo` "
+                  "(soon `vsdehalo.fine_dehalo`)! This function will be removed in a future commit.",
+                  DeprecationWarning)
     try:
         from havsfunc import DeHalo_alpha
     except ModuleNotFoundError:

--- a/lvsfunc/mask.py
+++ b/lvsfunc/mask.py
@@ -10,7 +10,7 @@ from vsutil import Range as CRange
 from vsutil import depth, get_depth, get_y, iterate, join, split
 
 from . import util
-from .types import Position, Range, Size
+from .types import Position, Range, Shapes, Size
 from .util import (check_variable, check_variable_resolution, pick_removegrain,
                    replace_ranges, scale_peak, scale_thresh)
 


### PR DESCRIPTION
Concerns #85.

@DonCanjas sent me the updated FineDehalo.avsi (from [here](https://github.com/realfinder/AVS-Stuff/blob/ae15f8b642e6c231389171169dee972602ed9ccd/avs%202.5%20and%20up/FineDehalo.avsi), presumably).

The biggest difference I've noticed between this and the older port are:

* AVS+ support
* Masking logic being separated
* New functions (for contrasharpening and analog?)

For the time being, I only followed the masking separation. This allows users to also run just the mask directly without needing to worry about running the extra code in `dehalo.fine_dehalo`.

Would also appreciate @realfinder's thoughts on this PR. Whether I missed other updates, and whether it's worth changing more things.