### PR TITLE
Backport vsencode `source` updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,7 @@ autodoc_mock_imports = [
     "vsaa",
     "vsscale",
     "vsdehalo",
+    "vsparsedvd",
 ]
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/submodules/helpers.rst
+++ b/docs/submodules/helpers.rst
@@ -9,10 +9,6 @@ These can be used by users as well.
 
     lvsfunc.helpers._check_has_nvidia
     lvsfunc.helpers._check_index_exists
-    lvsfunc.helpers._generate_dgi
-    lvsfunc.helpers._get_dgidx
-    lvsfunc.helpers._load_dgi
-    lvsfunc.helpers._tail
 
 .. automodule:: lvsfunc.helpers
     :members:

--- a/lvsfunc/aa.py
+++ b/lvsfunc/aa.py
@@ -48,7 +48,6 @@ def clamp_aa(src: vs.VideoNode, weak: vs.VideoNode, strong: vs.VideoNode, streng
 
     :return:            Clip with clamped anti-aliasing.
     """
-
     warnings.warn('lvsfunc.clamp_aa: deprecated in favor of vsaa.clamp_aa!', DeprecationWarning)
 
     return vsaa.clamp_aa(src, weak, strong, strength)
@@ -68,7 +67,6 @@ def taa(clip: vs.VideoNode, aafun: Callable[[vs.VideoNode], vs.VideoNode] | Sing
 
     :return:            Antialiased clip.
     """
-
     warnings.warn('lvsfunc.taa: deprecated in favor of vsaa.transpose_aa!', DeprecationWarning)
 
     if isinstance(aafun, SingleRater):
@@ -154,7 +152,6 @@ def nneedi3_clamp(clip: vs.VideoNode, strength: float = 1,
 
     :return:                    Antialiased clip.
     """
-
     warnings.warn('lvsfunc.nneedi3_clamp: deprecated in favor of vsaa.masked_clamp_aa!', DeprecationWarning)
 
     return vsaa.masked_clamp_aa(clip, strength, mthr, mask, opencl=opencl)
@@ -185,7 +182,6 @@ def transpose_aa(clip: vs.VideoNode, eedi3: bool = False, rep: int = 13) -> vs.V
 
     :return:          Antialiased clip.
     """
-
     warnings.warn('lvsfunc.transpose_aa: deprecated in favor of vsaa.fine_aa!', DeprecationWarning)
 
     return vsaa.fine_aa(clip, True, vsaa.Eedi3() if eedi3 else vsaa.Nnedi3(), rep)
@@ -231,7 +227,6 @@ def upscaled_sraa(clip: vs.VideoNode,
 
     :raises ValueError:     ``rfactor`` is not above 1.
     """
-
     warnings.warn('lvsfunc.upscaled_sraa: deprecated in favor of vsaa.upscaled_sraa!', DeprecationWarning)
 
     if isinstance(supersampler, SuperSampler):

--- a/lvsfunc/comparison.py
+++ b/lvsfunc/comparison.py
@@ -619,7 +619,7 @@ def diff(*clips: vs.VideoNode,
 
     if clips and not all([c.format for c in clips]):
         raise VariableFormatError("diff")
-    elif namedclips and not all([nc.format for nc in namedclips.values()]):
+    elif namedclips and not all([nc.format for nc in namedclips.values()]):  # noqa
         raise VariableFormatError("diff")
 
     def _to_ranges(iterable: list[int]) -> Iterable[tuple[int, int]]:

--- a/lvsfunc/dehalo.py
+++ b/lvsfunc/dehalo.py
@@ -55,7 +55,6 @@ def bidehalo(clip: vs.VideoNode, ref: vs.VideoNode | None = None,
 
     :return:                    Dehalo'd clip.
     """
-
     warnings.warn('lvsfunc.bidehalo: deprecated in favor of vsdehalo.bidehalo!', DeprecationWarning)
 
     return vsdehalo.bidehalo(
@@ -222,7 +221,6 @@ def fine_dehalo(clip: vs.VideoNode, ref: vs.VideoNode | None = None,
 
     :raises ModuleNotFoundError:    Dependencies are missing.
     """
-
     warnings.warn('lvsfunc.fine_dehalo: deprecated in favor of vsdehalo.fine_dehalo!', DeprecationWarning)
 
     return vsdehalo.fine_dehalo(

--- a/lvsfunc/dehardsub.py
+++ b/lvsfunc/dehardsub.py
@@ -54,8 +54,10 @@ class HardsubMask(DeferredMask, ABC):
         pdhs = [hrdsb]
         dmasks = []
         partials = partials + [ref]
+
         assert masks[-1].format is not None
         thresh = scale_thresh(0.75, masks[-1])
+
         for p in partials:
             masks.append(core.akarin.Expr([masks[-1], self.get_mask(p, ref)], expr="x y -"))
             dmasks.append(iterate(core.akarin.Expr([masks[-1]], f"x {thresh} < 0 x ?"),
@@ -63,6 +65,7 @@ class HardsubMask(DeferredMask, ABC):
                                   4).std.Inflate())
             pdhs.append(core.std.MaskedMerge(pdhs[-1], p, dmasks[-1]))
             masks[-1] = core.std.MaskedMerge(masks[-1], masks[-1].std.Invert(), masks[-2])
+
         return pdhs, dmasks
 
     def apply_dehardsub(self, hrdsb: vs.VideoNode, ref: vs.VideoNode,

--- a/lvsfunc/deinterlace.py
+++ b/lvsfunc/deinterlace.py
@@ -498,7 +498,7 @@ def fix_telecined_fades(clip: vs.VideoNode, tff: bool | int | None = None, cuda:
 
         avg_props_clip = mean_plane_value(fields, [0.0, 1.0], cuda=True, prop='psmAvg', single_out=True, planes=0)
     else:
-        avg_props_clip = fields.psm.PlaneAverage(value_exclude=[0.0, 1.0])
+        avg_props_clip = fields.psm.PlaneAverage(value_exclude=[0.0, 1.0])  # type:ignore
 
     def props_bodge(f: list[vs.VideoFrame], n: int) -> vs.VideoFrame:
         fout = f[0].copy()

--- a/lvsfunc/helpers.py
+++ b/lvsfunc/helpers.py
@@ -1,25 +1,18 @@
 from __future__ import annotations
 
-import os
 import subprocess as sp
-from collections import deque
 from pathlib import Path
-from typing import Any, cast
 
 import vapoursynth as vs
 from vsutil import is_image
 
-from .types import IndexExists, VSIdxFunction
+from .types import IndexFile, IndexingType, IndexType
 
 core = vs.core
 
 __all__ = [
     '_check_has_nvidia',
-    '_check_index_exists',
-    '_generate_dgi',
-    '_get_dgidx',
-    '_load_dgi',
-    '_tail'
+    '_check_index_exists'
 ]
 
 
@@ -32,69 +25,19 @@ def _check_has_nvidia() -> bool:
         return False
 
 
-def _get_dgidx() -> tuple[str, VSIdxFunction]:
-    """Return the dgindex idx as a string and the actual source filter."""
-    has_nv = _check_has_nvidia()
-
-    dgidx = 'DGIndexNV' if has_nv else 'DGIndex'
-    dgsrc = core.dgdecodenv.DGSource if has_nv else core.dgdecode.DGSource  # type:ignore[attr-defined]
-
-    return dgidx, dgsrc
-
-
-def _check_index_exists(path: os.PathLike[str] | str) -> IndexExists:
+def _check_index_exists(path: str | Path) -> IndexFile | IndexType:
     """Check whether a lwi or dgi exists. Returns an IndexExists Enum."""
-    path = str(path)
+    path = Path(path)
 
-    if path.endswith('.dgi'):
-        return IndexExists.PATH_IS_DGI
-    elif is_image(path):
-        return IndexExists.PATH_IS_IMG
-    elif Path(f"{path}.dgi").exists():
-        return IndexExists.DGI_EXISTS
-    elif Path(f"{path}.lwi").exists():
-        return IndexExists.LWI_EXISTS
-    return IndexExists.NONE
+    for itype in IndexingType:
+        if path.suffix == itype.value:
+            return IndexFile(itype, path.exists())
 
+    for itype in IndexingType:
+        if path.with_suffix(f'{path.suffix}{itype.value}').exists():
+            return IndexFile(itype, True)
 
-def _generate_dgi(path: str, idx: str) -> bool:
-    """Generate a dgi file using the given indexer and verify it exists."""
-    filename, _ = os.path.splitext(path)
-    output = f'{filename}.dgi'
+    if is_image(str(path)):
+        return IndexType.IMAGE
 
-    if not os.path.exists(output):
-        try:
-            sp.run([idx, '-i', path, '-o', output, '-h'])
-        except sp.CalledProcessError:
-            return False
-
-    return os.path.exists(output)
-
-
-def _tail(filename: str, n: int = 10) -> tuple[int, float]:
-    """Return the last n lines of a file."""
-    with open(filename, "r") as f:
-        lines = deque(f, n)
-        lines = cast(deque[str], [line for line in lines if 'FILM' in line or 'ORDER' in line])
-
-        if len(lines) == 1:
-            return (int(lines[0].split(' ')[1]), 0.00)
-
-        return (int(lines.pop().split(" ")[1].replace("\n", "")),
-                float(lines.pop().split(" ")[0].replace("%", "")))
-
-
-def _load_dgi(path: str, film_thr: float, src_filter: VSIdxFunction,
-              order: int, film: float, **index_args: Any) -> vs.VideoNode:
-    """
-    Run the source filter on the given dgi.
-
-    If order > 0 and FILM % > 99%, it will automatically enable `fieldop=1`.
-    """
-    props = dict(dgi_order=order, dgi_film=film, dgi_fieldop=0, lvf_idx='DGIndex(NV)')
-
-    if 'fieldop' not in index_args and (order > 0 and film >= film_thr):
-        index_args['fieldop'] = 1
-        props |= dict(dgi_fieldop=1, _FieldBased=0)
-
-    return src_filter(path, **index_args).std.SetFrameProps(**props)
+    return IndexType.NONE

--- a/lvsfunc/progress.py
+++ b/lvsfunc/progress.py
@@ -13,5 +13,8 @@ __all__ = [
 
 
 class FPSColumn(ProgressColumn):
+    """Progress rendering."""
+
     def render(self, task: Task) -> Text:
+        """Render bar."""
         return Text(f"{task.speed or 0:.02f} fps")

--- a/lvsfunc/render.py
+++ b/lvsfunc/render.py
@@ -27,9 +27,8 @@ __all__ = [
 
 
 class RenderContext:
-    """
-    Contains info on the current render operation.
-    """
+    """Contains info on the current render operation."""
+
     clip: vs.VideoNode
     queued: int
     frames: dict[int, vs.VideoFrame]
@@ -72,8 +71,9 @@ def clip_async_render(clip: vs.VideoNode,
                       progress: str | None = "Rendering clip...",
                       callback: RenderCallback | list[RenderCallback] | None = None) -> list[float]:
     """
-    Render a clip by requesting frames asynchronously using clip.get_frame_async,
-    providing for callback with frame number and frame object.
+    Render a clip by requesting frames asynchronously using clip.get_frame_async.
+
+    You must provide a callback with frame number and frame object.
 
     This is mostly a re-implementation of VideoNode.output, but a little bit slower since it's pure python.
     You only really need this when you want to render a clip while operating on each frame in order
@@ -194,7 +194,7 @@ def clip_async_render(clip: vs.VideoNode,
 
 
 def get_render_progress() -> Progress:
-    """Returns render progress."""
+    """Return render progress."""
     return Progress(
         TextColumn("{task.description}"),
         BarColumn(),

--- a/lvsfunc/scale.py
+++ b/lvsfunc/scale.py
@@ -39,7 +39,6 @@ def descale_detail_mask(clip: vs.VideoNode, rescaled_clip: vs.VideoNode,
 
     :return:               Mask of lost detail.
     """
-
     warnings.warn(
         'lvsfunc.descale_detail_mask: deprecated in favor of vsscale.descale_detail_mask!', DeprecationWarning
     )
@@ -106,7 +105,6 @@ def descale(clip: vs.VideoNode,
     :raises ValueError:     Asymmetric number of heights and widths are specified.
     :raises RuntimeError:   Variable clip gets returned.
     """
-
     warnings.warn(
         'lvsfunc.descale_detail_mask: deprecated in favor of vsscale.descale_detail_mask!', DeprecationWarning
     )
@@ -178,7 +176,6 @@ def ssim_downsample(clip: vs.VideoNode, width: int | None = None, height: int = 
 
     :return:            Downsampled clip.
     """
-
     warnings.warn('lvsfunc.ssim_downsample: deprecated in favor of vsscale.SSIM!', DeprecationWarning)
 
     if isinstance(kernel, str):
@@ -199,7 +196,6 @@ def gamma2linear(clip: vs.VideoNode, curve: Transfer, gcor: float = 1.0,
         | This function has been deprecated! It will be removed in a future commit.
 
     """
-
     warnings.warn('lvsfunc.gamma2linear: deprecated in favor of vsscale.gamma2linear!', DeprecationWarning)
 
     return vsscale.gamma2linear(clip, curve, gcor, sigmoid, thr, cont, epsilon)
@@ -215,7 +211,6 @@ def linear2gamma(clip: vs.VideoNode, curve: Transfer, gcor: float = 1.0,
         | This function has been deprecated! It will be removed in a future commit.
 
     """
-
     warnings.warn('lvsfunc.linear2gamma: deprecated in favor of vsscale.linear2gamma!', DeprecationWarning)
 
     return vsscale.linear2gamma(clip, curve, gcor, sigmoid, thr, cont)
@@ -241,7 +236,6 @@ def comparative_descale(clip: vs.VideoNode, width: int | None = None, height: in
 
     :raises CompareSameKernelError:     py:class:`vskernels.BicubicSharp` gets passed to ``kernel``.
     """
-
     warnings.warn(
         'lvsfunc.comparative_descale: deprecated in favor of vsscale.descale with mode=DescaleMode.KernelDiff!',
         DeprecationWarning
@@ -271,7 +265,6 @@ def comparative_restore(clip: vs.VideoNode, width: int | None = None, height: in
 
     :raises CompareSameKernelError:     py:class:`vskernels.BicubicSharp` gets passed to ``kernel``.
     """
-
     warnings.warn(
         'lvsfunc.comparative_restore: deprecated in favor of vsscale.descale with mode=DescaleMode.KernelDiff!',
         DeprecationWarning

--- a/lvsfunc/types.py
+++ b/lvsfunc/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from enum import IntEnum, auto
+from dataclasses import dataclass
+from enum import Enum, IntEnum, auto
 from typing import Any, NamedTuple, Protocol, Tuple
 
 import vapoursynth as vs
@@ -91,3 +92,34 @@ class _VideoNode(vs.VideoNode):
     """Use for asserting a VideoFormat exists."""
 
     format: vs.VideoFormat
+
+
+class IndexingType(str, Enum):
+    """Indexing types."""
+
+    DGI = '.dgi'
+    LWI = '.lwi'
+
+
+@dataclass
+class IndexFile:
+    """Type of index file."""
+
+    type: IndexingType
+    exists: bool
+
+
+class IndexType(IntEnum):
+    """Type of index."""
+
+    IMAGE = auto()
+    NONE = auto()
+
+
+class MissingT:
+    """Missing."""
+
+    pass
+
+
+MISSING = MissingT()

--- a/lvsfunc/util.py
+++ b/lvsfunc/util.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, cast
 
 import vapoursynth as vs
 from typing_extensions import TypeGuard
-from vskernels import Bicubic, Kernel, VNodeCallable, get_kernel, get_matrix, get_prop
+from vskernels import Bicubic, Kernel, Matrix, VNodeCallable, get_kernel, get_prop
 from vsutil import depth, get_subsampling, get_w, get_y
 
 from .exceptions import InvalidFormatError, VariableFormatError, VariableResolutionError
@@ -549,7 +549,8 @@ def match_clip(clip: vs.VideoNode, ref: vs.VideoNode,
     clip = kernel.scale(clip, ref.width, ref.height) if dimensions else clip
 
     if vformat:
-        clip = kernel.resample(clip, format=ref.format, matrix=get_matrix(ref))
+        assert ref.format
+        clip = kernel.resample(clip, format=ref.format, matrix=Matrix.from_video(ref))
 
     if matrices:
         ref_frame = ref.get_frame(0)
@@ -557,7 +558,8 @@ def match_clip(clip: vs.VideoNode, ref: vs.VideoNode,
         clip = clip.std.SetFrameProps(
             _Matrix=get_prop(ref_frame, '_Matrix', int),
             _Transfer=get_prop(ref_frame, '_Transfer', int),
-            _Primaries=get_prop(ref_frame, '_Primaries', int))
+            _Primaries=get_prop(ref_frame, '_Primaries', int)
+        )
 
     return clip.std.AssumeFPS(fpsnum=ref.fps.numerator, fpsden=ref.fps.denominator)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ vskernels>=1.2.0
 vsrgtools>=1.0.0
 vsscale>=1.0.0
 vsutil>=0.8.0
+vsparsedvd>=0.0.4


### PR DESCRIPTION
Setsu and I updated `source` in vsencode (called `index_clip` there), and I'm backporting it for now since that updated function is on a separate branch.

Also fixed a bunch of flake8 issues while I was at it.