### PR TITLE
bump tag exists action version

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check if version exists
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: mukunku/tag-exists-action@v1.0.0
+        uses: mukunku/tag-exists-action@v1.1.0
         id: tagcheck
         with:
           tag: ${{ env.CURR_VER }}


### PR DESCRIPTION
This PR bumps the tag-exists-action version to v1.1.0 which should get rid of _some of_ [these warnings](https://github.com/Irrational-Encoding-Wizardry/lvsfunc/actions/runs/3324418853):
![image](https://user-images.githubusercontent.com/4502154/198847972-86f78376-3101-4090-9b0b-0f34e3d5c7e7.png)
